### PR TITLE
handle "stack not found" as error

### DIFF
--- a/pprof_analysis.go
+++ b/pprof_analysis.go
@@ -225,14 +225,21 @@ func assertStackPercent(t *testing.T, prof []StackSample, regexpStack string, pc
 	}
 	var total int64 = 0
 	var matching int64 = 0
+    var found bool = false;
 	for _, ss := range prof {
 		total += ss.Val
 		if r.MatchString(ss.Stack) {
 			if labels == nil || checkLabels(t, ss.Labels, labels) {
 				matching += ss.Val
+                found = true;
 			}
 		}
 	}
+
+    if (!found) {
+        t.Errorf("Assertion failed: stack '%s' not found", regexpStack);
+        return;
+    }
 
 	var actualPct int64 = 0
 	if total != 0 {

--- a/pprof_analysis.go
+++ b/pprof_analysis.go
@@ -225,21 +225,21 @@ func assertStackPercent(t *testing.T, prof []StackSample, regexpStack string, pc
 	}
 	var total int64 = 0
 	var matching int64 = 0
-    var found bool = false;
+	var found bool = false
 	for _, ss := range prof {
 		total += ss.Val
 		if r.MatchString(ss.Stack) {
 			if labels == nil || checkLabels(t, ss.Labels, labels) {
 				matching += ss.Val
-                found = true;
+				found = true
 			}
 		}
 	}
 
-    if (!found) {
-        t.Errorf("Assertion failed: stack '%s' not found", regexpStack);
-        return;
-    }
+	if !found {
+		t.Errorf("Assertion failed: stack '%s' not found", regexpStack)
+		return
+	}
 
 	var actualPct int64 = 0
 	if total != 0 {


### PR DESCRIPTION
This PR will handle a stack not found as an error from now on. Prior to this PR this was handled as if the sample at this stack was 0.

The reason is that in https://github.com/DataDog/dd-trace-php/pull/2201 we wanted to check for the existence of a stack, but we do not care about the sample count or size, just that this stack exists in the resulting pprof. By setting the `error_margin` to 100% the test succeeded although the `regular_expression` had an error. We could have set the `error_margin` to 99% and rolled with it, but this would have made the test flaky and I think that generally speaking: if a stack is missing, this should be handled as a failure.