### PR TITLE
Remove stale context

### DIFF
--- a/scenarios/python_basic/expected_profile.json
+++ b/scenarios/python_basic/expected_profile.json
@@ -55,19 +55,6 @@
               ]
             }
           ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;target",
-          "percent": 5,
-          "error_margin": 2,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "Thread-2 (target)"
-              ]
-            }
-          ]
         }
       ]
     }


### PR DESCRIPTION
The basic scenario for the Python profiler had a stack where the target was mis-attributed to the profiler.  This is a defect that was fixed in the Python profiler a long time ago, so no need to check for it now.