### PR TITLE
Add a correctness test for Node.js Code Hotspots

### DIFF
--- a/scenarios/node_code_hotspots/Dockerfile
+++ b/scenarios/node_code_hotspots/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:18-bullseye
+
+# Give everyone write permissions in /app because profile is written here
+RUN mkdir /app && chmod a+rwX /app
+WORKDIR /app
+
+COPY ./scenarios/node_code_hotspots/* ./
+RUN chmod 755 /app/*
+RUN npm install
+
+ENV EXECUTION_TIME_SEC="10"
+ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
+ENV DD_PROFILING_EXPORTERS=file
+ENV DD_PROFILING_ENABLED=1
+ENV DD_TRACING_ENABLED=1
+ENV DD_REMOTE_CONFIGURATION_ENABLED=0
+ENV DD_PROFILING_PROFILERS=wall
+ENV DD_TRACE_DEBUG=1
+ENV DD_PROFILING_CODEHOTSPOTS_ENABLED=1
+ENV DD_PROFILING_ENDPOINT_COLLECTION_ENABLED=1
+CMD node -r dd-trace/init main.js

--- a/scenarios/node_code_hotspots/expected_profile.json
+++ b/scenarios/node_code_hotspots/expected_profile.json
@@ -1,0 +1,235 @@
+{
+  "test_name": "node_code_hotspots",
+  "stacks": [
+    {
+      "profile-type": "wall",
+      "stack-content": [
+        {
+          "regular_expression": "busyLoop22",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "span id",
+              "values": [
+                "12"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "9"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-2"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop21",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "span id",
+              "values": [
+                "11"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "9"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-2"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop20",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "span id",
+              "values": [
+                "10"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "9"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-2"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop12",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "local root span id",
+              "values": [
+                "5"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-1"
+              ]
+            },
+            {
+              "key": "span id",
+              "values": [
+                "8"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop11",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "local root span id",
+              "values": [
+                "5"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-1"
+              ]
+            },
+            {
+              "key": "span id",
+              "values": [
+                "7"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop10",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "local root span id",
+              "values": [
+                "5"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-1"
+              ]
+            },
+            {
+              "key": "span id",
+              "values": [
+                "6"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop02",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-0"
+              ]
+            },
+            {
+              "key": "span id",
+              "values": [
+                "4"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "1"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop01",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "span id",
+              "values": [
+                "3"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "1"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-0"
+              ]
+            }
+          ]
+        },
+        {
+          "regular_expression": "busyLoop00",
+          "percent": 11,
+          "error_margin": 1,
+          "labels": [
+            {
+              "key": "span id",
+              "values": [
+                "2"
+              ]
+            },
+            {
+              "key": "local root span id",
+              "values": [
+                "1"
+              ]
+            },
+            {
+              "key": "trace endpoint",
+              "values": [
+                "endpoint-0"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/node_code_hotspots/main.js
+++ b/scenarios/node_code_hotspots/main.js
@@ -1,0 +1,117 @@
+'use strict'
+
+const DDTrace = require('dd-trace')
+const tracer = DDTrace.init()
+
+const OUTER_ROUNDS = 3
+const INNER_ROUNDS = 3
+
+let counter = 0
+
+setTimeout(runBusySpans, 100)
+
+function runBusySpans () {
+  tracer.trace('x' + counter, (span, done) => {
+    // Make the span ID deterministic for the test.
+    // NOTE: this (obviously) depends on unsupported internals of dd-trace-js as
+    // it is accessing _* named properties. This is fine in tests, but can
+    // obviously cause test failures if these internals change. Since this is
+    // all internal to Datadog, we can adjust the tests if they break due to
+    // internal changes in dd-trace-js.
+    const rootSpanId = ((INNER_ROUNDS + 1) * counter) + 1
+    span._spanContext._spanId._buffer = [0, 0, 0, 0, 0, 0, 0, rootSpanId]
+
+    // Add tags for endpoint tracing
+    span.setTag('span.type', 'web')
+    span.setTag('resource.name', `endpoint-${counter}`)
+
+    setImmediate(() => {
+      for (let i = 0; i < INNER_ROUNDS; ++i) {
+        const z = i
+        tracer.trace('y' + i, (span2, done2) => {
+          // Make the span ID deterministic for the test as above
+          span2._spanContext._spanId._buffer = [0, 0, 0, 0, 0, 0, 0, rootSpanId + z + 1]
+          setTimeout(() => {
+            // Make sure we have a (counter, z) specific frame on stack
+            switch (counter) {
+              case 0:
+                switch (i) {
+                  case 0: busyLoop00(); break
+                  case 1: busyLoop01(); break
+                  case 2: busyLoop02(); break
+                }
+                break
+              case 1:
+                switch (i) {
+                  case 0: busyLoop10(); break
+                  case 1: busyLoop11(); break
+                  case 2: busyLoop12(); break
+                }
+                break
+              case 2:
+                switch (i) {
+                  case 0: busyLoop20(); break
+                  case 1: busyLoop21(); break
+                  case 2: busyLoop22(); break
+                }
+                break
+            }
+            done2()
+            if (z === (INNER_ROUNDS - 1)) {
+              if (++counter < OUTER_ROUNDS) {
+                setTimeout(runBusySpans, 0)
+              }
+              done()
+            }
+          }, 0)
+        })
+      }
+    })
+  })
+}
+
+function busyLoop () {
+  const start = process.hrtime.bigint()
+  for (;;) {
+    const now = process.hrtime.bigint()
+    if (now - start > 505050505n) {
+      break
+    }
+  }
+}
+
+function busyLoop00 () {
+  busyLoop()
+}
+
+function busyLoop01 () {
+  busyLoop()
+}
+
+function busyLoop02 () {
+  busyLoop()
+}
+
+function busyLoop10 () {
+  busyLoop()
+}
+
+function busyLoop11 () {
+  busyLoop()
+}
+
+function busyLoop12 () {
+  busyLoop()
+}
+
+function busyLoop20 () {
+  busyLoop()
+}
+
+function busyLoop21 () {
+  busyLoop()
+}
+
+function busyLoop22 () {
+  busyLoop()
+}

--- a/scenarios/node_code_hotspots/package.json
+++ b/scenarios/node_code_hotspots/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "correctness",
+  "version": "1.0.0",
+  "main": "main.js",
+  "license": "MIT",
+  "dependencies": {
+    "dd-trace": "DataDog/dd-trace-js#master"
+  },
+  "overrides": {
+    "@datadog/pprof": "dev"
+  }
+}


### PR DESCRIPTION
Adds a correctness test for Node.js Code Hotspots and Endpoint Tracing. The test program will yield a profile with samples having 9 distinct combinations of `span id`, `root span id`, and `trace endpoint` labels, in equal proportions (11% each)