### PR TITLE
PROF-8545: Fix the test to mark web spans before they start executing

### DIFF
--- a/scenarios/node_code_hotspots/main.js
+++ b/scenarios/node_code_hotspots/main.js
@@ -11,7 +11,7 @@ let counter = 0
 setTimeout(runBusySpans, 100)
 
 function runBusySpans () {
-  tracer.trace('x' + counter, (span, done) => {
+  tracer.trace('x' + counter, { type: 'web', resource: `endpoint-${counter}` }, (span, done) => {
     // Make the span ID deterministic for the test.
     // NOTE: this (obviously) depends on unsupported internals of dd-trace-js as
     // it is accessing _* named properties. This is fine in tests, but can
@@ -20,10 +20,6 @@ function runBusySpans () {
     // internal changes in dd-trace-js.
     const rootSpanId = ((INNER_ROUNDS + 1) * counter) + 1
     span._spanContext._spanId._buffer = [0, 0, 0, 0, 0, 0, 0, rootSpanId]
-
-    // Add tags for endpoint tracing
-    span.setTag('span.type', 'web')
-    span.setTag('resource.name', `endpoint-${counter}`)
 
     setImmediate(() => {
       for (let i = 0; i < INNER_ROUNDS; ++i) {

--- a/scenarios/node_heap_oom/expected_profile.json
+++ b/scenarios/node_heap_oom/expected_profile.json
@@ -5,7 +5,7 @@
       "profile-type": "space",
       "stack-content": [
         {
-          "regular_expression": "processTimers;listOnTimeout;\\(anonymous\\);foo",
+          "regular_expression": "processTimers;listOnTimeout;\\(anonymous:L#13:C#30\\);foo",
           "percent": 97,
           "error_margin": 3
         }


### PR DESCRIPTION
Same change as in the [dd-trace-js integration test](https://github.com/DataDog/dd-trace-js/pull/3792/files#diff-a43aa088a563861822b155e2d9b2483b68a4977197851c989b4abd81b2d3b190L21-R21).