### PR TITLE
Increase error margin on node_wall_cpu

### DIFF
--- a/scenarios/node_wall_cpu/expected_profile.json
+++ b/scenarios/node_wall_cpu/expected_profile.json
@@ -113,7 +113,7 @@
           "regular_expression": "foo;b",
           "percent": 66,
           "value": 400000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -131,7 +131,7 @@
           "regular_expression": "foo;a",
           "percent": 33,
           "value": 200000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -155,7 +155,7 @@
           "regular_expression": "foo;b",
           "percent": 66,
           "value": 400000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -173,7 +173,7 @@
           "regular_expression": "foo;a",
           "percent": 33,
           "value": 200000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",


### PR DESCRIPTION
Increase error margin for worker to reduce test flakiness.