### PR TITLE
Update values for ddprof live heap test

### DIFF
--- a/scenarios/ddprof_live_heap/expected_profile.json
+++ b/scenarios/ddprof_live_heap/expected_profile.json
@@ -7,8 +7,8 @@
         {
           
           "regular_expression": ".*leak_function\\(int\\)",
-          "percent": 70,
-          "error_margin": 20
+          "percent": 100,
+          "error_margin": 5
         }
       ]
     },
@@ -18,8 +18,8 @@
         {
           
           "regular_expression": ".*leak_function\\(int\\)",
-          "percent": 90,
-          "error_margin": 10
+          "percent": 100,
+          "error_margin": 5
         }
       ]
     }


### PR DESCRIPTION
Now that allocations from profiling library are ignored (in particular buffer allocated by statically linked libstdc++ for exceptions), values need to be updated.