### PR TITLE
[PROF-9179] Ruby allocation correctness check

### DIFF
--- a/scenarios/ruby_allocations/Dockerfile
+++ b/scenarios/ruby_allocations/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:3.3
+
+ENV DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED true
+ENV DD_TRACE_DEBUG true
+ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
+
+# Copy the Ruby program into the container
+COPY ./scenarios/ruby_allocations/gems.rb ./scenarios/ruby_allocations/main.rb /app/
+RUN chmod 644 /app/*
+
+# Set the working directory to the location of the program
+WORKDIR /app
+
+RUN bundle install
+
+# Run the program when the container starts
+CMD bundle exec ddtracerb exec ruby main.rb

--- a/scenarios/ruby_allocations/expected_profile.json
+++ b/scenarios/ruby_allocations/expected_profile.json
@@ -1,0 +1,230 @@
+{
+  "test_name": "ruby_allocations",
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "alloc-samples",
+      "error-margin": 3,
+      "value-matching-sum": 500,
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;a$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread75"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;a$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread25"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;a;\\*$",
+          "percent": 30,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread75"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;a;\\*$",
+          "percent": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread25"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;b;new$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_OBJECT"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "ComplexObject"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread75"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;b;new$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread25"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_OBJECT"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "ComplexObject"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;b;new;initialize;new$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread75"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_ARRAY"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "Array"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\u003cmain\u003e;allocate_stuff;b;new;initialize;new$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread25"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_ARRAY"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "Array"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/ruby_allocations/gems.rb
+++ b/scenarios/ruby_allocations/gems.rb
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'ddtrace', git: 'https://github.com/DataDog/dd-trace-rb.git', branch: 'master'
-gem 'google-protobuf'

--- a/scenarios/ruby_allocations/gems.rb
+++ b/scenarios/ruby_allocations/gems.rb
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'ddtrace', git: 'https://github.com/DataDog/dd-trace-rb.git', branch: 'master'
+gem 'google-protobuf'

--- a/scenarios/ruby_allocations/main.rb
+++ b/scenarios/ruby_allocations/main.rb
@@ -1,0 +1,81 @@
+# The Ruby profiler does not (yet) include a way of exporting a pprof to a file, so we implement it here:
+class ExportToFile
+  PPROF_PREFIX = ENV.fetch('DD_PROFILING_PPROF_PREFIX')
+
+  def export(flush)
+    File.write("#{PPROF_PREFIX}#{flush.start.strftime('%Y%m%dT%H%M%SZ')}.pprof", flush.pprof_data)
+    true
+  end
+end
+
+Datadog.configure do |c|
+  c.profiling.enabled = true
+  c.profiling.exporter.transport = ExportToFile.new
+end
+
+def a
+  # This is intentionally inneficient to see if we capture it. You may naively assume this leads
+  # to 2 string allocations ('a' and the expansion of 'a' to size 1024 * 120) but the rules of
+  # the * operator precedence means we'll do:
+  # * Allocate one string directly (>a)
+  # * Allocate another string of size 1024 as a result of the first call of * (>a>*)
+  # * Allocate another string of size 1024*120 as a result of the second call of * (>a>*)
+  'a' * 1024 * 120
+end
+
+class ComplexObject
+  def initialize
+    @data_storage = Array.new(1024)
+  end
+end
+
+def b
+  ComplexObject.new
+end
+
+$test_duration = 50
+exec_time_env = ENV['EXECUTION_TIME_SEC']
+if exec_time_env
+  $test_duration = exec_time_env.to_i
+  exit(1) if $test_duration.zero?
+end
+
+puts "Executable #{__FILE__} starting for #{$test_duration} seconds"
+
+def allocate_stuff(loops_per_sec:)
+  sum_sleep_time = 0
+  end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) + $test_duration
+  iterations = 0
+  time_per_loop = (1.0 / loops_per_sec)
+  sleep_budget = 0
+  while (start = Process.clock_gettime(Process::CLOCK_MONOTONIC)) < end_time
+    a # 3 String allocations per loop exec.
+    b # 1 Object allocation + 1 Array allocation per loop exec.
+
+    stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    sleep_budget += time_per_loop
+    iterations += 1
+    elapsed = stop - start
+    sleep_budget -= elapsed
+    time_to_sleep = sleep_budget.positive? ? sleep_budget : 0
+    sleep(time_to_sleep)
+    slept = Process.clock_gettime(Process::CLOCK_MONOTONIC) - stop
+    sleep_budget -= slept
+    sum_sleep_time += slept
+  end
+  puts "Thread #{Thread.current.name} finished with #{iterations} iterations and #{sum_sleep_time} total sleep time"
+end
+
+threads = []
+threads << Thread.new do
+  Thread.current.name = 'thread75'
+  allocate_stuff(loops_per_sec: 75) # 75 * 5=375 allocs/sec
+end
+threads << Thread.new do
+  Thread.current.name = 'thread25'
+  allocate_stuff(loops_per_sec: 25) # 25 * 5=125 allocs/sec
+end
+
+threads.each(&:join) # Total expectation of 500 allocs/sec
+
+puts "Executable #{__FILE__} finished successfully"

--- a/scenarios/ruby_allocations/main.rb
+++ b/scenarios/ruby_allocations/main.rb
@@ -92,6 +92,6 @@ threads << Thread.new do
   allocate_stuff(loops_per_sec: thread2_loops_per_sec)
 end
 
-threads.each(&:join) # Total expectation of 5 * loops_per_sec allocs/sec
+threads.each(&:join) # Total expectation of 5 * loops_per_sec allocs/sec (value-matching-sum in json)
 
 puts "Executable #{__FILE__} finished successfully"

--- a/scenarios/ruby_allocations_highload/Dockerfile
+++ b/scenarios/ruby_allocations_highload/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:3.3
+
+ENV DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED true
+ENV DD_TRACE_DEBUG true
+ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
+
+# Copy the Ruby program into the container
+COPY ./scenarios/ruby_allocations/gems.rb ./scenarios/ruby_allocations/main.rb /app/
+RUN chmod 644 /app/*
+
+# Set the working directory to the location of the program
+WORKDIR /app
+
+RUN bundle install
+
+# Run the program when the container starts
+ENV LOOPS_PER_SEC 1000
+CMD bundle exec ddtracerb exec ruby main.rb

--- a/scenarios/ruby_allocations_highload/expected_profile.json
+++ b/scenarios/ruby_allocations_highload/expected_profile.json
@@ -1,0 +1,230 @@
+{
+  "test_name": "ruby_allocations",
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "alloc-samples",
+      "error-margin": 12,
+      "value-matching-sum": 5000,
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^<main>;allocate_stuff;a$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread750"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;a$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread250"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;a;\\*$",
+          "percent": 30,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread750"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;a;\\*$",
+          "percent": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread250"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_STRING"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "String"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;b;new$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_OBJECT"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "ComplexObject"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "thread750"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;b;new$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread250"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_OBJECT"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "ComplexObject"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;b;new;initialize;new$",
+          "percent": 15,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread750"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_ARRAY"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "Array"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^<main>;allocate_stuff;b;new;initialize;new$",
+          "percent": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "thread250"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "ruby vm type",
+              "values": [
+                "T_ARRAY"
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "allocation class",
+              "values": [
+                "Array"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/ruby_basic/gems.rb
+++ b/scenarios/ruby_basic/gems.rb
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'ddtrace'
-gem 'google-protobuf'


### PR DESCRIPTION
* Add the ability to specify profile-type-wide error margins.
* Add the ability to specify an expectation for the total sum of stack values for the provided stack content matches (allowing you to assert relative weights between individual stacks via percent expectations as well as an expectation for the sum of all of those values; previously you'd be forced to have individual value matches which was not only redundant but would also require custom error margins for each individual value).
* Introduce 2 new Ruby test cases where 2 Ruby threads do several allocations of different object types. One of the threads does 3x more work than the other.
  * One flavour aims for 500 ops/sec - Low enough that sampling probabilities are high so low errors are expected:
    ```
    "allocation_sampled": 12394,
    "allocation_skipped": 12927,
    "allocation_effective_sample_rate": 0.48947513921251135,
    "allocation_sampling_time_ns_min": 1542,
    "allocation_sampling_time_ns_max": 4950958,
    "allocation_sampling_time_ns_total": 351162278,
    "allocation_sampling_time_ns_avg": 28333.248184605454,
    "allocation_sampler_snapshot": {
      "target_overhead": 1,
      "target_overhead_adjustment": -0.004410022455738587,
      "events_per_sec": 499.6921771357948,
      "sampling_time_ns": 33381,
      "sampling_interval": 2,
      "sampling_probability": 60.287056858048274,
      "events_since_last_readjustment": 161,
      "samples_since_last_readjustment": 80
    },
    ```
  * Another flavour aims for 5000 ops/sec - Involves a bit more sampling so will naturally incur slightly more errors (we bump error margin from 3% to 12% for it)
    ```
    "allocation_sampled": 9847,
    "allocation_skipped": 240155,
    "allocation_effective_sample_rate": 0.03938768489852081,
    "allocation_sampling_time_ns_min": 2667,
    "allocation_sampling_time_ns_max": 12404125,
    "allocation_sampling_time_ns_total": 458839935,
    "allocation_sampling_time_ns_avg": 46596.92647506855,
    "allocation_sampler_snapshot": {
      "target_overhead": 1,
      "target_overhead_adjustment": -0.07701004002245126,
      "events_per_sec": 5006.143515150073,
      "sampling_time_ns": 39977,
      "sampling_interval": 22,
      "sampling_probability": 4.6549025030022975,
      "events_since_last_readjustment": 1051,
      "samples_since_last_readjustment": 47
    },

    ```