### PR TITLE
Add regex to select correct profile file

### DIFF
--- a/scenarios/node_code_hotspots/expected_profile.json
+++ b/scenarios/node_code_hotspots/expected_profile.json
@@ -3,6 +3,7 @@
   "stacks": [
     {
       "profile-type": "wall",
+      "pprof-regex": "profiles_wall_worker_0_.*.pprof",
       "stack-content": [
         {
           "regular_expression": "busyLoop22",


### PR DESCRIPTION
Timeline is nowenabled by default, therefore two pprof files are produced and we need to select the correct one.