### PR TITLE
[NO-TICKET] Fix Ruby jobs failing due to library rename

### DIFF
--- a/scenarios/ruby_allocations/Dockerfile
+++ b/scenarios/ruby_allocations/Dockerfile
@@ -14,4 +14,4 @@ WORKDIR /app
 RUN bundle install
 
 # Run the program when the container starts
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb

--- a/scenarios/ruby_allocations/gems.rb
+++ b/scenarios/ruby_allocations/gems.rb
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'ddtrace', git: 'https://github.com/DataDog/dd-trace-rb.git', branch: 'master'
+gem 'datadog', git: 'https://github.com/datadog/dd-trace-rb.git', branch: 'master'

--- a/scenarios/ruby_allocations_highload/Dockerfile
+++ b/scenarios/ruby_allocations_highload/Dockerfile
@@ -15,4 +15,4 @@ RUN bundle install
 
 # Run the program when the container starts
 ENV LOOPS_PER_SEC 1000
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb

--- a/scenarios/ruby_basic/Dockerfile
+++ b/scenarios/ruby_basic/Dockerfile
@@ -14,4 +14,4 @@ WORKDIR /app
 RUN bundle install
 
 # Run the program when the container starts
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb

--- a/scenarios/ruby_basic/gems.rb
+++ b/scenarios/ruby_basic/gems.rb
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'ddtrace'
+gem 'datadog', git: 'https://github.com/datadog/dd-trace-rb.git', branch: 'master'

--- a/scenarios/ruby_heap/Dockerfile
+++ b/scenarios/ruby_heap/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /app
 RUN bundle install
 
 # Run the program when the container starts
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb

--- a/scenarios/ruby_heap/gems.rb
+++ b/scenarios/ruby_heap/gems.rb
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'ddtrace', git: 'https://github.com/DataDog/dd-trace-rb.git', branch: 'master'
+gem 'datadog', git: 'https://github.com/datadog/dd-trace-rb.git', branch: 'master'

--- a/scenarios/ruby_heap_bias/Dockerfile
+++ b/scenarios/ruby_heap_bias/Dockerfile
@@ -20,4 +20,4 @@ RUN bundle install
 ENV DISABLE_RESHUFFLE="true"
 
 # Run the program when the container starts
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb

--- a/scenarios/ruby_heap_highload/Dockerfile
+++ b/scenarios/ruby_heap_highload/Dockerfile
@@ -18,4 +18,4 @@ RUN bundle install
 ENV LOOPS_PER_SEC=500
 
 # Run the program when the container starts
-CMD bundle exec ddtracerb exec ruby main.rb
+CMD bundle exec ddprofrb exec ruby main.rb


### PR DESCRIPTION
**What does this PR do?**

This PR changes prof-correctness to match the library rename for version 2 of the Ruby library.

* The gem is now called `datadog` instead of `ddtrace`
* The Ruby profiler command wrapper is called `ddprofrb` instead of `ddtracerb`

**Motivation:**

Because prof-correctness was running using the latest version of the Ruby library from the master branch, it broke when the 2.0 development branch (which included the library rename) was merged to master in https://github.com/DataDog/dd-trace-rb/pull/3421 .

**Additional Notes:**

I don't expect customers to run into the same issue, since you wouldn't normally be sourcing the library from master directly (that's really bleeding edge!).

**How to test the change?**

Validate that prof-correctlness Ruby CI jobs are passing again.