### PR TITLE
Remove PHP from nightly run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ jobs:
     with:
       test_scenarios: ddprof.*
     secrets: inherit
-  php:
-    uses: ./.github/workflows/test.yml
-    with:
-      test_scenarios: php.*
-    secrets: inherit
   ruby:
     uses: ./.github/workflows/test.yml
     with:
@@ -29,4 +24,3 @@ jobs:
     with:
       test_scenarios: python.*
     secrets: inherit
- 


### PR DESCRIPTION
PHP has migrated to use this repo to analyze using the GitHub Action exposed:
https://github.com/DataDog/prof-correctness?tab=readme-ov-file#using-as-a-github-action

Notification of the slack channel has been added to `dd-trace-php` via https://github.com/DataDog/dd-trace-php/pull/2654