### PR TITLE
[NO-TICKET] Fix ruby app build broken by upstream update

### DIFF
--- a/scenarios/ruby_basic/Dockerfile
+++ b/scenarios/ruby_basic/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.7
 
+# To avoid an issue with the ffi gem, we need to upgrade rubygems.
+# 3.4.22 is the last version that works with Ruby 2.7; never versions no longer work
+RUN gem update --system 3.4.22
+
 ENV DD_PROFILING_FORCE_ENABLE_NEW true
 ENV DD_TRACE_DEBUG true
 ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"


### PR DESCRIPTION
**What does this PR do?**

This PR fixes the issue we saw in CI for our test Ruby apps:

```
Resolving dependencies...
ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22, which is
incompatible with the current version, 3.1.6
```

by upgrading the rubygems version, as requested.

**Motivation:**

Fix prof-correctness validations for Ruby.

**Additional Notes:**

This upstream update is a bit of a mess... `ffi` is an indirect dependency of dd-trace-rb (through libddwaf) and upstream released this new version that requires a quite modern version of rubygems.

**How to test the change?**

Validate that CI is green again.

Here's the output of building the docker image with the fix:

```
$ docker build . -f scenarios/ruby_basic/Dockerfile
[+] Building 42.6s (11/11) FINISHED                                                 docker:default
 => [internal] load build definition from Dockerfile                                  0.0s
 => => transferring dockerfile: 520B                                                  0.0s
 => [internal] load metadata for docker.io/library/ruby:2.7                           0.6s
 => [internal] load .dockerignore                                                     0.0s
 => => transferring context: 2B                                                       0.0s
 => CACHED [1/6] FROM docker.io/library/ruby:2.7@sha256:2347de892e419c7160fc21dec72   0.0s
 => [internal] load build context                                                     0.0s
 => => transferring context: 166B                                                     0.0s
 => [2/6] RUN gem update --system 3.4.22                                             22.6s
 => [3/6] COPY ./scenarios/ruby_basic/gems.rb ./scenarios/ruby_basic/main.rb /app/    0.1s
 => [4/6] RUN chmod 644 /app/*                                                        0.5s
 => [5/6] WORKDIR /app                                                                0.1s
 => [6/6] RUN bundle install                                                         17.5s
 => exporting to image                                                                0.9s
 => => exporting layers                                                               0.9s
 => => writing image sha256:994b63f3640ddaf869cac276a8f979619cb685be061b2a9c136d5e0b020fd43c
```