### PR TITLE
Allow to use numeric labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/dbenamy/profiler-correctness/v1
 go 1.19
 
 require (
-	github.com/google/pprof v0.0.0-20210423192551-a2663126120b
-	github.com/pierrec/lz4/v4 v4.1.18
+	github.com/google/pprof v0.0.0-20240528025155-186aa0362fba
+	github.com/pierrec/lz4/v4 v4.1.21
 )

--- a/go.sum
+++ b/go.sum
@@ -3,9 +3,13 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/google/pprof v0.0.0-20210423192551-a2663126120b h1:l2YRhr+YLzmSp7KJMswRVk/lO5SwoFIcCLzJsVj+YPc=
 github.com/google/pprof v0.0.0-20210423192551-a2663126120b/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20240528025155-186aa0362fba h1:ql1qNgCyOB7iAEk8JTNM+zJrgIbnyCKX/wdlyPufP5g=
+github.com/google/pprof v0.0.0-20240528025155-186aa0362fba/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pprof_analysis.go
+++ b/pprof_analysis.go
@@ -271,6 +271,7 @@ func getProfileType(t *testing.T, profile *profile.Profile, type_ string) []Stac
 			for _, i := range v {
 				labels[k] = append(labels[k], strconv.FormatInt(i, 10))
 			}
+            sort.Strings(labels[k]);
 		}
 
 		ss := StackSample{

--- a/pprof_analysis.go
+++ b/pprof_analysis.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -149,7 +150,7 @@ func contains_str(s []string, v string) bool {
 
 func captureProfData(t *testing.T, prof *profile.Profile, path string, testName string, profileDuration float64) {
 	// labels to ignore
-	keysToIgnore := []string{"thread id", "thread native id"}
+	keysToIgnore := []string{"thread native id"}
 
 	var capturedData StackTestData
 	capturedData.TestName = testName
@@ -237,7 +238,7 @@ func getProfileType(t *testing.T, profile *profile.Profile, type_ string) []Stac
 	// t.Logf("Found '%s' smaple type at idx %d\n", type_, typeIdx)
 
 	// if err := profile.Aggregate(true, true, false, p.LineNumbers, false); err != nil {
-	if err := profile.Aggregate(true, true, false, false, false); err != nil {
+	if err := profile.Aggregate(true, true, false, false, false, false); err != nil {
 		t.Fatalf("Error aggregating profile samples: %v", err)
 	}
 	profile = profile.Compact()
@@ -266,6 +267,12 @@ func getProfileType(t *testing.T, profile *profile.Profile, type_ string) []Stac
 			labels[k] = v
 			// t.Log("Sorted labels :", v)
 		}
+		for k, v := range sample.NumLabel {
+			for _, i := range v {
+				labels[k] = append(labels[k], strconv.FormatInt(i, 10))
+			}
+		}
+
 		ss := StackSample{
 			Stack:  strings.Join(frames, ";"),
 			Val:    sample.Value[typeIdx],


### PR DESCRIPTION
So far only string labels where matched in the `expected.json`'s. With this PR we'll add support to also match numeric labels. This is needed for PHP to validate the `thread id` label being there. As this is an ID and the actual value being unstable, you can use `values_regex` for this as in this PHP example:

```json
{
    "test_name": "php_exception",
    "stacks": [
        {
            "profile-type": "exception-samples",
            "stack-content": [
                {
                    "regular_expression": "<\\?php;FooBar\\\\throwAndCatch",
                    "percent": 100,
                    "labels": [
                        {
                            "key": "exception type",
                            "values": [
                                "FooBar\\Exception"
                            ]
                        },
                        {
                            "key": "thread id",
                            "values_regex": "^[0-9]+$"
                        }
                    ]
                }
            ]
        }
    ]
}
```

This ensures not a specific value, but the label being there.

Additionally: so far we do not have tests that include the `end_timestamp_ns` label being around which is a label that we need to create for timeline events. Merging this PR would allow us to add those tests as well.

[PROF-9911](https://datadoghq.atlassian.net/browse/PROF-9911)

[PROF-9911]: https://datadoghq.atlassian.net/browse/PROF-9911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ