### PR TITLE
[NO-TICKET] Minor: Use `wait_until_running` for ruby tests

### DIFF
--- a/scenarios/ruby_allocations/main.rb
+++ b/scenarios/ruby_allocations/main.rb
@@ -17,13 +17,7 @@ Datadog.configure do |c|
   c.profiling.exporter.transport = ExportToFile.new
 end
 
-Timeout.timeout(5) do
-  until Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_is_running?(
-    Datadog.send(:components).profiler.send(:worker)
-  )
-    sleep(0.5)
-  end
-end
+Datadog::Profiling.wait_until_running
 
 def a
   # This is intentionally inneficient to see if we capture it. You may naively assume this leads

--- a/scenarios/ruby_basic/main.rb
+++ b/scenarios/ruby_basic/main.rb
@@ -15,13 +15,7 @@ Datadog.configure do |c|
   c.profiling.exporter.transport = ExportToFile.new
 end
 
-Timeout.timeout(5) do
-  until Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_is_running?(
-    Datadog.send(:components).profiler.send(:worker)
-  )
-    sleep(0.5)
-  end
-end
+Datadog::Profiling.wait_until_running
 
 def a
   x = 0

--- a/scenarios/ruby_heap/main.rb
+++ b/scenarios/ruby_heap/main.rb
@@ -33,13 +33,7 @@ end
 
 setup_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-Timeout.timeout(5) do
-  until Datadog::Profiling::Collectors::CpuAndWallTimeWorker::Testing._native_is_running?(
-    Datadog.send(:components).profiler.send(:worker)
-  )
-    sleep(0.5)
-  end
-end
+Datadog::Profiling.wait_until_running
 
 # Approx 1KB per living object (memsize_of says 1041) (e.g. 5MB for 5k live objects)
 def a


### PR DESCRIPTION
**What does this PR do?**

The Ruby profiler runs in a background thread, and so often in our tests we need a way to make sure the profiler is already running before we actually start the test (otherwise we may miss some of the data which may lead to flaky failures).

I got tired of this boilerplate and introduced an actual API to do this in the profiler -- `Datadog::Profiling.wait_until_running`.

This PR replaces our previous hacky boilerplate to ensure the profiler was running with this new API.

**Motivation:**

Reduce boilerplate in tests.

**Additional Notes:**

N/A

**How to test the change?**

Validate that Ruby scenarios still pass.