### PR TITLE
[NO-TICKET] Fix flakiness in Ruby allocation tests by disabling telemetry

### DIFF
--- a/scenarios/ruby_allocations/main.rb
+++ b/scenarios/ruby_allocations/main.rb
@@ -15,6 +15,7 @@ end
 Datadog.configure do |c|
   c.profiling.enabled = true
   c.profiling.exporter.transport = ExportToFile.new
+  c.telemetry.enabled = false
 end
 
 Datadog::Profiling.wait_until_running

--- a/scenarios/ruby_heap/main.rb
+++ b/scenarios/ruby_heap/main.rb
@@ -29,6 +29,7 @@ end
 Datadog.configure do |c|
   c.profiling.enabled = true
   c.profiling.exporter.transport = ExportToFile.new
+  c.telemetry.enabled = false
 end
 
 setup_end = Process.clock_gettime(Process::CLOCK_MONOTONIC)


### PR DESCRIPTION
**What does this PR do?**

This PR disables the telemetry feature of the Ruby library for the allocations and heap tests.

It does this to solve the flakiness of Ruby allocation tests that appeared
[on nightly runs after July 10th](https://github.com/DataDog/prof-correctness/actions).

[For instance](https://github.com/DataDog/prof-correctness/actions/runs/9883228606/job/27308478303):

```
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;a$' (labels=[{ruby vm type [T_STRING] } {allocation class [String] } {thread name [thread75] }]) is 15% +/- 3% of the profile (was 13% with 2% error)
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;a$' (labels=[{allocation class [String] } {thread name [thread25] } {ruby vm type [T_STRING] }]) is 5% +/- 3% of the profile (was 4% with 1% error)
    pprof_analysis.go:357: Assertion failed: stack '^<main>;allocate_stuff;a;\*$' (labels=[{ruby vm type [T_STRING] } {allocation class [String] } {thread name [thread75] }]) should have been 30% +/- 3% of the profile but was 26% with 4% error
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;a;\*$' (labels=[{thread name [thread25] } {ruby vm type [T_STRING] } {allocation class [String] }]) is 10% +/- 3% of the profile (was 8% with 2% error)
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;b;new$' (labels=[{ruby vm type [T_OBJECT] } {allocation class [ComplexObject] } {thread name [thread75] }]) is 15% +/- 3% of the profile (was 14% with 1% error)
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;b;new$' (labels=[{thread name [thread25] } {ruby vm type [T_OBJECT] } {allocation class [ComplexObject] }]) is 5% +/- 3% of the profile (was 5% with 0% error)
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;b;new;initialize;new$' (labels=[{thread name [thread75] } {ruby vm type [T_ARRAY] } {allocation class [Array] }]) is 15% +/- 3% of the profile (was 13% with 2% error)
    pprof_analysis.go:359: Assertion succeeded: stack '^<main>;allocate_stuff;b;new;initialize;new$' (labels=[{thread name [thread25] } {ruby vm type [T_ARRAY] } {allocation class [Array] }]) is 5% +/- 3% of the profile (was 4% with 1% error)
    pprof_analysis.go:397: Assertion succeeded: profile 'alloc-samples' has total matching sum of 25004 +/- 3% (was 25011 with 0.0% error)
```

Since we've been commiting a few changes to the allocation profiler, I was really confused there for a while on what happened -- I was not seeing any regression on the allocation performance or behavior.

In fact, what happened was that a few changes to the telemetry implementation were merged around that time. Since telemetry runs as a background thread, these allocations were being counted towards the total, and since the `ruby_allocations` test scenario has (on purpose):

* A low number of allocations
* A low error margin

...The extra allocations were actually enough to cause our numbers to cross the error margin. If you re-examine the numbers above, you'll note that every number is coming in at or **below** the expected percentage -- never above. This explains why: there was a % of allocations that did not belong to any of the two threads we were asserting, but again were counted towards the total.

**Motivation:**

Bring prof-correctness back to green.

**Additional Notes:**

Something something integration tests offering more integration than we bargained for.

**How to test the change?**

Validate that CI is back to green.