### PR TITLE
fix broken python 3.10 test

### DIFF
--- a/scenarios/python_basic_3.11/expected_profile.json
+++ b/scenarios/python_basic_3.11/expected_profile.json
@@ -1,76 +1,62 @@
 {
   "test_name": "python_basic",
+  "scale_by_duration": true,
+  "pprof-regex": "",
   "stacks": [
     {
       "profile-type": "wall-time",
+      "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;wait;wait",
-          "percent": 22,
-          "error_margin": 3,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "ddtrace.profiling.scheduler:Scheduler"
-              ]
-            }
-          ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;wait;wait",
-          "percent": 22,
-          "error_margin": 3,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "ddtrace.profiling.collector.memalloc:MemoryCollector"
-              ]
-            }
-          ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;periodic",
-          "percent": 22,
-          "error_margin": 3,
+          "regular_expression": "^periodic$",
+          "percent": 40,
+          "error_margin": 6,
           "labels": [
             {
               "key": "thread name",
               "values": [
                 "ddtrace.profiling.collector.stack:StackCollector"
-              ]
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "class name",
+              "values": [
+                "StackCollector"
+              ],
+              "values_regex": ""
             }
           ]
         },
         {
-          "regular_expression": "<module>;target",
-          "percent": 22,
-          "error_margin": 2,
+          "regular_expression": "^\u003cmodule\u003e;target$",
+          "percent": 40,
+          "error_margin": 3,
           "labels": [
             {
               "key": "thread name",
               "values": [
                 "MainThread"
-              ]
+              ],
+              "values_regex": ""
             }
           ]
         },
         {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;target",
-          "percent": 11,
-          "error_margin": 2,
+          "regular_expression": "^_bootstrap;_bootstrap_inner;run;target$",
+          "percent": 19,
+          "error_margin": 3,
           "labels": [
             {
               "key": "thread name",
               "values": [
                 "Thread-1 (target)"
-              ]
+              ],
+              "values_regex": ""
             }
           ]
         }
       ]
     }
-  ],
-  "scale_by_duration": true
+  ]
 }

--- a/scenarios/python_basic_gevent/expected_profile.json
+++ b/scenarios/python_basic_gevent/expected_profile.json
@@ -1,107 +1,97 @@
 {
   "test_name": "python_basic",
+  "scale_by_duration": true,
+  "pprof-regex": "",
   "stacks": [
     {
       "profile-type": "wall-time",
+      "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;wait;wait",
-          "percent": 11,
-          "error_margin": 2,
+          "regular_expression": "^periodic$",
+          "percent": 32,
+          "error_margin": 5,
           "labels": [
             {
-              "key": "thread name",
+              "key": "class name",
               "values": [
-                "ddtrace.profiling.scheduler:Scheduler"
-              ]
-            }
-          ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;wait;wait",
-          "percent": 11,
-          "error_margin": 2,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "ddtrace.profiling.collector.memalloc:MemoryCollector"
-              ]
-            }
-          ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;periodic",
-          "percent": 11,
-          "error_margin": 2,
-          "labels": [
+                "StackCollector"
+              ],
+              "values_regex": ""
+            },
             {
               "key": "thread name",
               "values": [
                 "ddtrace.profiling.collector.stack:StackCollector"
-              ]
+              ],
+              "values_regex": ""
             }
           ]
         },
         {
-          "regular_expression": "run",
-          "percent": 5,
+          "regular_expression": "^\u003cmodule\u003e;target;sleep$",
+          "percent": 23,
           "error_margin": 4,
           "labels": [
             {
               "key": "thread name",
               "values": [
                 "MainThread"
-              ]
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "task name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        },
+        {
+          "regular_expression": "^run$",
+          "percent": 23,
+          "error_margin": 4,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
             },
             {
               "key": "class name",
               "values": [
                 "Hub"
-              ]
+              ],
+              "values_regex": ""
             }
           ]
         },
         {
-          "regular_expression": "<module>;target;sleep",
-          "percent": 5,
-          "error_margin": 4,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ]
-            },
-            {
-              "key": "task name",
-              "values": [
-                "MainThread"
-              ]
-            }
-          ]
-        },
-        {
-          "regular_expression": "_bootstrap;_bootstrap_inner;run;target;sleep",
-          "percent": 4,
+          "regular_expression": "^_bootstrap;_bootstrap_inner;run;target;sleep$",
+          "percent": 11,
           "error_margin": 2,
           "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ]
-            },
             {
               "key": "task name",
               "values": [
                 "Thread-1 (target)"
-              ]
+              ],
+              "values_regex": ""
+            },
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
             }
           ]
         }
       ]
     }
-  ],
-  "scale_by_duration": true
+  ]
 }


### PR DESCRIPTION
ddtrace recently shifted to a different native periodic thread implementation.  I don't fully understand why the 3.11 tests are working, but the 3.10 tests reveal the absence of some systems, which I expect.  It could be that things just work differently on 3.11 and later.

Either way, this fixes the test by tuning it to the data we actually see.