### PR TITLE
[python] Add asyncio check

### DIFF
--- a/scenarios/python_asyncio_3.11/Dockerfile
+++ b/scenarios/python_asyncio_3.11/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+RUN pip install ddtrace
+
+# Copy the Python target into the container
+COPY ./scenarios/python_asyncio_3.11/main.py /app/
+RUN chmod 644 /app/*
+
+# Set the working directory to the location of the program
+WORKDIR /app
+
+# Run the program when the container starts
+CMD python main.py

--- a/scenarios/python_asyncio_3.11/expected_profile.json
+++ b/scenarios/python_asyncio_3.11/expected_profile.json
@@ -1,0 +1,32 @@
+{
+  "test_name": "python_asyncio",
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;main;my_coroutine",
+          "value": 1025498000,
+          "error_margin": 20,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "Task-1"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_asyncio_3.11/main.py
+++ b/scenarios/python_asyncio_3.11/main.py
@@ -1,0 +1,41 @@
+import os
+import asyncio
+
+
+async def my_coroutine(n: float) -> None:
+    await asyncio.sleep(n)
+
+
+async def main() -> None:
+    # Simple application that creates two Tasks with different durations:
+    # - "unnamed Task" runs my_coroutine() for 2 second
+    # - short_task runs my_coroutine() for 1 second
+    # The profiler should capture both Tasks with their respective durations.
+
+    # Note: there currently is an issue in ddtrace that attaches one of the gathered Tasks to the "parent"
+    # task. As a result, using an explicit name for the manually started Task would result in flakiness (as we cannot
+    # know which Task name will be "absorbed" by the Parent).
+    # For the time being, we thus don't name the Task, so that we will always have Task-1 and Task-2 in the Profile.
+
+    # Note: additionally, there is an issue in how we count wall time that results in blatantly incorrect results.
+    # We are in the process of making asyncio better in dd-trace-py; we will update the correctness check once that
+    # issue is fixed.
+
+    from ddtrace.profiling import Profiler
+
+    prof = Profiler()
+    prof.start()  # Should be as early as possible, eg before other imports, to ensure everything is profiled
+
+    # Give the Profiler some time to start up
+    await asyncio.sleep(0.5)
+
+    EXECUTION_TIME_SEC = float(os.environ.get("EXECUTION_TIME_SEC", "2"))
+
+    short_task = asyncio.create_task(my_coroutine(EXECUTION_TIME_SEC / 2))
+
+    # asyncio.gather will automatically wrap my_coroutine into a Task
+    await asyncio.gather(short_task, my_coroutine(EXECUTION_TIME_SEC))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scenarios/python_asyncio_3.11/requirements.txt
+++ b/scenarios/python_asyncio_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What does this PR do?

This PR adds a new (very basic) correctness check for `asyncio` stacks.

Note that, for now, we focus on a basic use case, and we don't even get fully correct stacks as we don't have visibility into the `asyncio.sleep` call (not included in the expected regular expression).

This has been fixed in dd-trace-py but has not been released yet.