### PR TITLE
python: update gevent check

### DIFF
--- a/scenarios/python_basic_gevent/expected_profile.json
+++ b/scenarios/python_basic_gevent/expected_profile.json
@@ -9,8 +9,8 @@
       "stack-content": [
         {
           "regular_expression": ".*target.*",
-          "value": 717884000, 
-          "error_margin": 50,
+          "value": 1000000000,
+          "error_margin": 25,
           "labels": [
             {
               "key": "task name",

--- a/scenarios/python_basic_gevent/main.py
+++ b/scenarios/python_basic_gevent/main.py
@@ -2,21 +2,21 @@ from gevent import monkey
 
 monkey.patch_all()
 
-import os
-from threading import Thread
-from time import sleep
+import os  # noqa: E402
+from threading import Thread  # noqa: E402
 
 
-def target(n):
+def target(n: int) -> None:
     # Do actual work instead of just sleeping so profiler can capture it
     import time
+
     end_time = time.monotonic() + n
     count = 0
     while time.monotonic() < end_time:
         count += 1
         if count % 1000 == 0:
             # Yield to gevent
-            sleep(0.01)
+            time.sleep(0.01)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

This PR updates the `gevent basic` check to expect a value of `1000000000` for "being busy for 1s" (instead of what we used to expect). This is more faithful to what we should be seeing (and what we've been seeing lately with recent versions of ddtrace). 

The PR also makes a few improvements to the check script. 