### PR TITLE
[python_gunicorn] Add correctness check for `gunicorn`

### DIFF
--- a/scenarios/python_gunicorn_3.11/Dockerfile
+++ b/scenarios/python_gunicorn_3.11/Dockerfile
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+# Copy the Python target into the container
+COPY ./scenarios/python_gunicorn_3.11/requirements.txt /app/
+RUN chmod 644 /app/*
+
+# Set the working directory to the location of the program
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+COPY ./scenarios/python_gunicorn_3.11/main.py /app/
+
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=false
+ENV DD_TRACE_DEBUG=false
+ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"
+ENV EXECUTION_TIME_SEC="5"
+
+# Run the program when the container starts
+CMD ["ddtrace-run", "gunicorn", "main:app"]

--- a/scenarios/python_gunicorn_3.11/README.md
+++ b/scenarios/python_gunicorn_3.11/README.md
@@ -1,0 +1,10 @@
+# Description
+
+Correctness check for `gunicorn`.
+
+Because we want to run the test for a few seconds, then to exit automatically, the script is both the app definition and
+a worker thread that issues HTTP requests to the app. After a few seconds, a special request is sent which makes the app
+exit, terminating the process (at which point we look at the resulting Profiles from the testing framework).
+
+In the expected Profile, we look both at how much CPU and time the app consumes, and how much CPU and time the Requester
+thread uses.

--- a/scenarios/python_gunicorn_3.11/expected_profile.json
+++ b/scenarios/python_gunicorn_3.11/expected_profile.json
@@ -1,0 +1,102 @@
+{
+  "test_name": "python_gunicorn_3.11",
+  "scale_by_duration": false,
+  "pprof-regex": "profiles.*\\.pprof$",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "pprof-regex": "profiles\\.([2-9]|[1-9][0-9]+)\\..*\\.pprof$",
+      "stack-content": [
+        {
+          "regular_expression": ".*make_request.*",
+          "percent": 5,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "Requester"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "profiles\\.([2-9]|[1-9][0-9]+)\\..*\\.pprof$",
+      "stack-content": [
+        {
+          "regular_expression": ".*make_request.*",
+          "percent": 50,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "Requester"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "pprof-regex": "profiles\\.([2-9]|[1-9][0-9]+)\\..*\\.pprof$",
+      "stack-content": [
+        {
+          "regular_expression": ".*process.*",
+          "percent": 85,
+          "error_margin": 15,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "pprof-regex": "profiles\\.([2-9]|[1-9][0-9]+)\\..*\\.pprof$",
+      "stack-content": [
+        {
+          "regular_expression": ".*sub_process.*",
+          "percent": 15,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "profiles\\.([2-9]|[1-9][0-9]+)\\..*\\.pprof$",
+      "stack-content": [
+        {
+          "regular_expression": ".*process.*",
+          "percent": 50,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_gunicorn_3.11/main.py
+++ b/scenarios/python_gunicorn_3.11/main.py
@@ -1,0 +1,61 @@
+"""
+This is a correctness check for ddtrace with a very basic (sync) Gunicorn application.
+Gunicorn will run in the process we start and create one worker process.
+
+What we do is start a thread that will issue HTTP requests to the Gunicorn application.
+Processing this HTTP request will consume some CPU time (that we should profile).
+After a while, this threads sends a special HTTP request, asking to stop the application.
+"""
+
+import os
+import signal
+import time
+from collections.abc import Callable, Iterator
+from threading import Thread
+
+import requests
+
+
+def make_request() -> None:
+    expected_duration = int(os.environ.get("EXECUTION_TIME_SEC", "5"))
+
+    start = time.monotonic()
+    while time.monotonic() - start < expected_duration:
+        try:
+            requests.get("http://localhost:8000", timeout=1)
+        except Exception:  # noqa: PERF203,BLE001
+            print("Error making request")
+
+    requests.get("http://localhost:8000/stop", timeout=1)
+
+
+def sub_process(x: float) -> float:
+    return x * 1.0001
+
+
+def process(target: int) -> tuple[float, int]:
+    x = 1.0
+    i = 0
+    while x < target:
+        x = sub_process(x)
+        i += 1
+
+    return x, i
+
+
+def app(environ: dict[str, str], start_response: Callable[[str, list[tuple[str, str]]], None]) -> Iterator[bytes]:
+    x, iterations = process(target=123)
+    data = f"Result: {(x, iterations)}".encode()
+    status = "200 OK"
+    response_headers = [("Content-type", "text/plain"), ("Content-Length", str(len(data)))]
+
+    if environ["RAW_URI"] == "/stop":
+        os.kill(os.getppid(), signal.SIGQUIT)
+
+    start_response(status, response_headers)
+    return iter([data])
+
+
+t = Thread(target=make_request, name="Requester")
+t.daemon = True
+t.start()

--- a/scenarios/python_gunicorn_3.11/requirements.txt
+++ b/scenarios/python_gunicorn_3.11/requirements.txt
@@ -1,0 +1,3 @@
+ddtrace
+gunicorn
+requests


### PR DESCRIPTION
## What does this PR do?

https://datadoghq.atlassian.net/browse/PROF-13054

This PR adds a new correctness test for the Python Profiler, focused on ensuring Gunicorn workloads are properly profiled (for CPU Time and Wall Time). 

Because we want to run the test for a few seconds, then to exit automatically, the script is both the app definition and a worker thread that issues HTTP requests to the app. After a few seconds, a special request is sent which makes the app exit, terminating the process (at which point we look at the resulting Profiles from the testing framework).

