### PR TITLE
Improvements to test output

### DIFF
--- a/correctness_test.go
+++ b/correctness_test.go
@@ -120,7 +120,8 @@ func runTestApp(t *testing.T, dockerTag string, folder string) string {
 	}
 	// Outputs are written to /app/data
 	profilePath := currentPath + "/data"
-	tmpdir, err := os.MkdirTemp(profilePath, filepath.Base(folder)+"-*")
+	timestamp := time.Now().Format("20060102-150405")
+	tmpdir, err := os.MkdirTemp(profilePath, filepath.Base(folder)+"-"+timestamp+"-*")
 	if err != nil {
 		t.Fatalf("Failed to make tmp dir: %v", err)
 	}
@@ -189,7 +190,7 @@ func extractBaseImage(dockerfilePath string) (string, error) {
 	for scanner.Scan() && lineCount < 10 {
 		line := scanner.Text()
 		matches := regexp.MustCompile(`ARG BASE_IMAGE="(.+?)"`).FindStringSubmatch(line)
-		if matches != nil && len(matches) > 1 {
+		if len(matches) > 1 {
 			return matches[1], nil
 		}
 		lineCount++

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	fmt.Printf("This is not the real main, this is just a small helper main to open the json data \n")
 	fmt.Printf("Run the go test -v -run TestScenarios to run the tests\n")
-	filter := regexp.MustCompile("<?php;main;b;standard\\|str_repeat$")
+	filter := regexp.MustCompile(`<?php;main;b;standard\|str_repeat$`)
 	stringMatch := "<?php;main;b;standard|str_repeat"
 	if filter.MatchString(stringMatch) {
 		println("Yes, haha")

--- a/pprof_analysis.go
+++ b/pprof_analysis.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 
 	"github.com/google/pprof/profile"
-	"github.com/pierrec/lz4/v4"
 	"github.com/klauspost/compress/zstd"
+	"github.com/pierrec/lz4/v4"
 )
 
 var (
@@ -460,6 +460,26 @@ func readJSONFile(filePath string) (StackTestData, error) {
 	return data, nil
 }
 
+func getAllFiles(folder string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
 func getMatchingFiles(folder string, filenameRegex *regexp.Regexp) ([]string, error) {
 	var matchingFiles []string
 	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
@@ -582,6 +602,10 @@ func AnalyzeResults(t *testing.T, jsonFilePath string, pprof_folder string) {
 		}
 		if len(matchingFiles) == 0 {
 			t.Errorf("No matching files found for %s in %s", pprof_regexp, pprof_folder)
+
+			if allFiles, err := getAllFiles(pprof_folder); err == nil {
+				t.Errorf("All files: %v", allFiles)
+			}
 		} else {
 			// Sort files by name to ensure consistent ordering
 			sort.Strings(matchingFiles)


### PR DESCRIPTION
## What does this PR do?

This PR updates the "testing framework":
- Output directories now have the run date time as part of their suffix (⇒ they can be sorted by run time)
- Some static analysis/lint (`gopls`) fixes
- If no files matching the expected pattern are found, the list of all files is printed out