### PR TITLE
[python_uwsgi] Reintroduce upload interval config

### DIFF
--- a/scenarios/python_uwsgi_3.11/Dockerfile
+++ b/scenarios/python_uwsgi_3.11/Dockerfile
@@ -18,7 +18,11 @@ ENV DD_PROFILING_ENABLED=true
 ENV DD_TRACE_DEBUG=false
 ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
 ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"
-ENV EXECUTION_TIME_SEC=10
+
+# It's important that those are roughly the same, but execution time is slightly longer so
+# that we're sure the Profile has been dumped.
+ENV EXECUTION_TIME_SEC=11
+ENV DD_PROFILING_UPLOAD_INTERVAL=10
 
 # Run the program when the container starts
 CMD ["uwsgi", "--ini", "uwsgi.ini"]


### PR DESCRIPTION
## What does this PR do?

This PR reintroduces the `DD_PROFILING_UPLOAD_INTERVAL` environment variable, removed in https://github.com/DataDog/prof-correctness/pull/81 but that is actually necessary to get a `pprof` at all. I'm not sure what's going on, but it seems like for some reason, when using `uWSGI`, we don't correctly upload the last Profile before exiting the process.  In itself, this is a bug and we need to look into it (although customer impact should be fairly low for long-running uWSGI apps) but it is completely unrelated to the Profile data being correct, which is why I'm adding it back here. 