### PR TITLE
[python_asyncio] Update

### DIFF
--- a/scenarios/python_asyncio_3.11/Dockerfile
+++ b/scenarios/python_asyncio_3.11/Dockerfile
@@ -10,5 +10,11 @@ RUN chmod 644 /app/*
 # Set the working directory to the location of the program
 WORKDIR /app
 
+ENV DD_PROFILING_ENABLED=true
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
+ENV EXECUTION_TIME_SEC="3"
+ENV DD_PROFILING_MEMORY_ENABLED=false
+ENV DD_REMOTE_CONFIGURATION_ENABLED=false
+
 # Run the program when the container starts
-CMD python main.py
+CMD ddtrace-run python main.py

--- a/scenarios/python_asyncio_3.11/README.md
+++ b/scenarios/python_asyncio_3.11/README.md
@@ -1,0 +1,29 @@
+## Basic `asyncio` check
+
+### What it does
+
+This checks the correctness of a basic `asyncio`-based script.
+
+Default execution time is 3 seconds.
+
+The script has
+
+- `my_coroutine`: idle coroutine that just calls `asyncio.sleep`
+- `long_computation`: CPU-heavy coroutine that computes something
+- `async_def`: entry point, which
+  - Creates a `my_coroutine` Task (running in the background) for `EXEC_TIME / 2`, name is `short_task`
+  - Awaits `long_computation` for `EXEC_TIME / 3`
+  - Gathers the `short_task` (partially completed) and a new Task (`Task-3`) for `my_coroutine` for `EXEC_TIME`
+
+### Expected
+
+The expected Profile should have the following stacks:
+
+- `my_coroutine;sleep`: ~2 seconds in `short_task`
+- `main;long_computation`: ~1 second in `Task-1`
+- `main;my_coroutine`: ~1 second in `short_task`
+- `main;my_coroutine`: ~3 seconds in `Task-3`
+
+### TODO
+
+- [ ] Investigate why wall-time shows ~1.5 seconds instead of expected 2 seconds

--- a/scenarios/python_asyncio_3.11/expected_profile.json
+++ b/scenarios/python_asyncio_3.11/expected_profile.json
@@ -1,5 +1,5 @@
 {
-  "test_name": "python_asyncio",
+  "test_name": "python_asyncio_3.11",
   "pprof-regex": "",
   "stacks": [
     {
@@ -7,9 +7,34 @@
       "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;main;my_coroutine",
-          "value": 1025498000,
-          "error_margin": 20,
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*run;my_coroutine;sleep",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "short_task"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*run;async_main;long_computation",
+          "value": 1000000000,
+          "error_margin": 10,
           "labels": [
             {
               "key": "thread name",
@@ -21,6 +46,81 @@
               "key": "task name",
               "values": [
                 "Task-1"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*run;async_main;long_computation",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "Task-1"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;async_main;my_coroutine;sleep",
+          "value": 3000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "Task-3"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;async_main;my_coroutine;sleep",
+          "value": 500000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "short_task"
               ]
             }
           ]

--- a/scenarios/python_asyncio_3.11/requirements.txt
+++ b/scenarios/python_asyncio_3.11/requirements.txt
@@ -1,1 +1,0 @@
-ddtrace


### PR DESCRIPTION
## What is this PR?

This PR updates the `asyncio` check after recent updates / fixes to `asyncio` Task sampling, now that  https://github.com/DataDog/dd-trace-py/pull/15962 has been merged and backported to 4.2.

Also, this is still not 100% deterministic (sorry...). The test sometimes randomly fails because the profile doesn't have `short_task` as a Task name but... `<module>`. Why that is is really unclear to me, to be honest. I'm hoping this will fix it: https://github.com/DataDog/dd-trace-py/pull/16014.

The CI failure we have in the current run is unrelated to this fix (I have another PR up for it!)


This PR also reformats `python_greenlet`.