### PR TITLE
[python_asyncio] Fix some flakiness

### DIFF
--- a/scenarios/python_asyncio_3.11/Dockerfile
+++ b/scenarios/python_asyncio_3.11/Dockerfile
@@ -10,5 +10,9 @@ RUN chmod 644 /app/*
 # Set the working directory to the location of the program
 WORKDIR /app
 
+ENV ECHION_USE_FAST_COPY_MEMORY=1
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
+ENV DD_PROFILING_ENABLED=true
+
 # Run the program when the container starts
-CMD python main.py
+CMD ddtrace-run python main.py

--- a/scenarios/python_asyncio_3.11/expected_profile.json
+++ b/scenarios/python_asyncio_3.11/expected_profile.json
@@ -8,7 +8,7 @@
       "stack-content": [
         {
           "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;main;my_coroutine",
-          "value": 1025498000,
+          "value": 2525498000,
           "error_margin": 20,
           "labels": [
             {
@@ -20,7 +20,32 @@
             {
               "key": "task name",
               "values": [
-                "Task-1"
+                "short_task"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*;.*run;.*;BaseEventLoop\\.run_until_complete;.*;main;my_coroutine",
+          "value": 5000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ]
+            },
+            {
+              "key": "task name",
+              "values": [
+                "Task-3"
               ]
             }
           ]

--- a/scenarios/python_asyncio_3.11/main.py
+++ b/scenarios/python_asyncio_3.11/main.py
@@ -1,8 +1,6 @@
 import asyncio
 import os
 
-from ddtrace.profiling import Profiler
-
 
 async def my_coroutine(n: float) -> None:
     await asyncio.sleep(n)
@@ -14,24 +12,12 @@ async def main() -> None:
     # - short_task runs my_coroutine() for 1 second
     # The profiler should capture both Tasks with their respective durations.
 
-    # Note: there currently is an issue in ddtrace that attaches one of the gathered Tasks to the "parent"
-    # task. As a result, using an explicit name for the manually started Task would result in flakiness (as we cannot
-    # know which Task name will be "absorbed" by the Parent).
-    # For the time being, we thus don't name the Task, so that we will always have Task-1 and Task-2 in the Profile.
-
-    # Note: additionally, there is an issue in how we count wall time that results in blatantly incorrect results.
-    # We are in the process of making asyncio better in dd-trace-py; we will update the correctness check once that
-    # issue is fixed.
-
-    prof = Profiler()
-    prof.start()  # Should be as early as possible, eg before other imports, to ensure everything is profiled
-
     # Give the Profiler some time to start up
     await asyncio.sleep(0.5)
 
-    execution_time_sec = float(os.environ.get("EXECUTION_TIME_SEC", "2"))
+    execution_time_sec = float(os.environ.get("EXECUTION_TIME_SEC", "5"))
 
-    short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2))
+    short_task = asyncio.create_task(my_coroutine(execution_time_sec / 2.0), name="short_task")
 
     # asyncio.gather will automatically wrap my_coroutine into a Task
     await asyncio.gather(short_task, my_coroutine(execution_time_sec))


### PR DESCRIPTION
## What does this PR do?

This check is currently flaky, and currently uses `from ddtrace.profiling import Profiler` which is not the recommended way to use the Profiler. I think fixing this will also help with flakiness (it does when I try to reproduce locally anyway). 