### PR TITLE
[python_gunicorn] Fix expected numbers

### DIFF
--- a/scenarios/python_gunicorn_3.11/expected_profile.json
+++ b/scenarios/python_gunicorn_3.11/expected_profile.json
@@ -9,8 +9,8 @@
       "stack-content": [
         {
           "regular_expression": ".*make_request.*",
-          "percent": 5,
-          "error_margin": 10,
+          "percent": 28,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -47,8 +47,8 @@
       "stack-content": [
         {
           "regular_expression": ".*process.*",
-          "percent": 85,
-          "error_margin": 15,
+          "percent": 65,
+          "error_margin": 13,
           "labels": [
             {
               "key": "thread name",
@@ -66,8 +66,8 @@
       "stack-content": [
         {
           "regular_expression": ".*sub_process.*",
-          "percent": 15,
-          "error_margin": 10,
+          "percent": 6,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",


### PR DESCRIPTION
## What does this PR do?

This PR fixes the expected profiling numbers in the Gunicorn check. I suspect those changed because we now _always report_ CPU time even when we don't see Threads as "running", so we need to adjust. 