### PR TITLE
ci: support for downstream pipeline from `dd-trace-py`

### DIFF
--- a/.github/chainguard/dd-trace-py.gitlab.trigger-ci.sts.yaml
+++ b/.github/chainguard/dd-trace-py.gitlab.trigger-ci.sts.yaml
@@ -1,0 +1,14 @@
+# Policy for: .gitlab-ci.yml prof-correctness job in DataDog/apm-reliability/dd-trace-py
+# Allows dd-trace-py GitLab CI to trigger prof-correctness GitHub Actions workflows
+# when profiling code changes, to run correctness tests against just-built wheels.
+issuer: https://gitlab.ddbuild.io
+subject_pattern: project_path:DataDog/apm-reliability/dd-trace-py:ref_type:branch:ref:.*
+
+claim_pattern:
+  ci_config_ref_uri: gitlab\.ddbuild\.io/DataDog/apm-reliability/dd-trace-py//\.gitlab-ci\.yml@refs/heads/.*
+  pipeline_source: (push|schedule|web)
+  project_path: DataDog/apm-reliability/dd-trace-py
+  ref_path: refs/heads/.*
+
+permissions:
+  actions: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,8 @@ on:
   push:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch:
-    inputs:
-      dd_trace_py_commit_sha:
-        description: 'dd-trace-py commit SHA to test against (installs wheels from S3)'
-        required: false
-        type: string
-      test_scenarios:
-        description: 'Regexp to select which scenarios to run (default: python.*)'
-        required: false
-        type: string
-        default: 'python.*'
 jobs:
   schema-validation:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -27,7 +15,6 @@ jobs:
       - name: Run schema validation tests
         run: go test -v -run TestSchemaValidation
   ruff:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -43,25 +30,21 @@ jobs:
         if: success() || failure()
         run: ruff check .
   ddprof:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: ddprof.*
     secrets: inherit
   dotnet:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: dotnet.*
     secrets: inherit
   ruby:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: ruby.*
     secrets: inherit
   node:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: node.*
@@ -69,11 +52,9 @@ jobs:
   python:
     uses: ./.github/workflows/test.yml
     with:
-      test_scenarios: ${{ inputs.test_scenarios || 'python.*' }}
-      dd_trace_py_commit_sha: ${{ inputs.dd_trace_py_commit_sha || '' }}
+      test_scenarios: python.*
     secrets: inherit
   full_host:
-    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: full_host.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ on:
   push:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      dd_trace_py_commit_sha:
+        description: 'dd-trace-py commit SHA to test against (installs wheels from S3)'
+        required: false
+        type: string
+      test_scenarios:
+        description: 'Regexp to select which scenarios to run (default: python.*)'
+        required: false
+        type: string
+        default: 'python.*'
 jobs:
   schema-validation:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -15,6 +27,7 @@ jobs:
       - name: Run schema validation tests
         run: go test -v -run TestSchemaValidation
   ruff:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -30,21 +43,25 @@ jobs:
         if: success() || failure()
         run: ruff check .
   ddprof:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: ddprof.*
     secrets: inherit
   dotnet:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: dotnet.*
     secrets: inherit
   ruby:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: ruby.*
     secrets: inherit
   node:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: node.*
@@ -52,9 +69,11 @@ jobs:
   python:
     uses: ./.github/workflows/test.yml
     with:
-      test_scenarios: python.*
+      test_scenarios: ${{ inputs.test_scenarios || 'python.*' }}
+      dd_trace_py_commit_sha: ${{ inputs.dd_trace_py_commit_sha || '' }}
     secrets: inherit
   full_host:
+    if: ${{ !inputs.dd_trace_py_commit_sha }}
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: full_host.*

--- a/.github/workflows/downstream-python.yml
+++ b/.github/workflows/downstream-python.yml
@@ -1,0 +1,23 @@
+name: "Downstream: dd-trace-py"
+run-name: "dd-trace-py downstream (${{ inputs.dd_trace_py_commit_sha }})"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dd_trace_py_commit_sha:
+        description: 'dd-trace-py commit SHA to test against (installs wheels from S3)'
+        required: true
+        type: string
+      test_scenarios:
+        description: 'Regexp to select which scenarios to run'
+        required: false
+        type: string
+        default: 'python.*'
+
+jobs:
+  python:
+    uses: ./.github/workflows/test.yml
+    with:
+      test_scenarios: ${{ inputs.test_scenarios }}
+      ddtrace_install_url: "https://dd-trace-py-builds.s3.amazonaws.com/${{ inputs.dd_trace_py_commit_sha }}/install-manylinux2014_x86_64.sh"
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Docker scenarios
 run-name: Docker scenarios
 
-on: 
+on:
   workflow_call:
     inputs:
       test_scenarios:
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
         default: '.*'
+      dd_trace_py_commit_sha:
+        description: 'dd-trace-py commit SHA to test against (installs wheels from S3)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   docker-scenarios:
@@ -23,7 +28,16 @@ jobs:
     - name: Update perf_event_paranoid settings
       run: sudo sysctl kernel.perf_event_paranoid=1
     - name: Run Docker scenarios
-      run: go test -timeout 20m -v -run TestScenarios
+      run: |
+        SHA="${{ inputs.dd_trace_py_commit_sha }}"
+        echo "dd_trace_py_commit_sha input: '${SHA}'"
+        if [ -n "$SHA" ]; then
+          export DDTRACE_FIND_LINKS="https://dd-trace-py-builds.s3.amazonaws.com/${SHA}/index-manylinux2014_x86_64.html"
+          echo "Will install ddtrace wheels from: ${DDTRACE_FIND_LINKS}"
+        else
+          echo "No custom ddtrace wheels requested, using PyPI"
+        fi
+        go test -timeout 20m -v -run TestScenarios
       env:
         TEST_SCENARIOS: ${{ inputs.test_scenarios }}
     - name: Create unique artifact name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,9 @@ jobs:
     - name: Run Docker scenarios
       run: |
         SHA="${{ inputs.dd_trace_py_commit_sha }}"
-        echo "dd_trace_py_commit_sha input: '${SHA}'"
         if [ -n "$SHA" ]; then
-          export DDTRACE_FIND_LINKS="https://dd-trace-py-builds.s3.amazonaws.com/${SHA}/index-manylinux2014_x86_64.html"
-          echo "Will install ddtrace wheels from: ${DDTRACE_FIND_LINKS}"
+          export DDTRACE_INSTALL_URL="https://dd-trace-py-builds.s3.amazonaws.com/${SHA}/install-manylinux2014_x86_64.sh"
+          echo "Will install ddtrace from: ${DDTRACE_INSTALL_URL}"
         else
           echo "No custom ddtrace wheels requested, using PyPI"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
         required: false
         type: string
         default: '.*'
-      dd_trace_py_commit_sha:
-        description: 'dd-trace-py commit SHA to test against (installs wheels from S3)'
+      ddtrace_install_url:
+        description: 'URL to a ddtrace install script (e.g. from S3 builds)'
         required: false
         type: string
         default: ''
@@ -28,17 +28,10 @@ jobs:
     - name: Update perf_event_paranoid settings
       run: sudo sysctl kernel.perf_event_paranoid=1
     - name: Run Docker scenarios
-      run: |
-        SHA="${{ inputs.dd_trace_py_commit_sha }}"
-        if [ -n "$SHA" ]; then
-          export DDTRACE_INSTALL_URL="https://dd-trace-py-builds.s3.amazonaws.com/${SHA}/install-manylinux2014_x86_64.sh"
-          echo "Will install ddtrace from: ${DDTRACE_INSTALL_URL}"
-        else
-          echo "No custom ddtrace wheels requested, using PyPI"
-        fi
-        go test -timeout 20m -v -run TestScenarios
+      run: go test -timeout 20m -v -run TestScenarios
       env:
         TEST_SCENARIOS: ${{ inputs.test_scenarios }}
+        DDTRACE_INSTALL_URL: ${{ inputs.ddtrace_install_url }}
     - name: Create unique artifact name
       id: artifact_name
       if: failure()

--- a/base_images/Dockerfile.python-3.10
+++ b/base_images/Dockerfile.python-3.10
@@ -1,10 +1,10 @@
 FROM python:3.10
 
-# When set, pre-install ddtrace from this URL (pip --find-links compatible).
-# Used by upstream dd-trace-py CI to test with just-built wheels.
-ARG DDTRACE_FIND_LINKS=""
-RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
-      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
     fi
 
 ENV DD_PROFILING_ENABLED=true

--- a/base_images/Dockerfile.python-3.10
+++ b/base_images/Dockerfile.python-3.10
@@ -1,5 +1,12 @@
 FROM python:3.10
 
+# When set, pre-install ddtrace from this URL (pip --find-links compatible).
+# Used by upstream dd-trace-py CI to test with just-built wheels.
+ARG DDTRACE_FIND_LINKS=""
+RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
+      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+    fi
+
 ENV DD_PROFILING_ENABLED=true
 ENV DD_TRACE_ENABLED=false
 ENV DD_TRACE_DEBUG=true

--- a/base_images/Dockerfile.python-3.11
+++ b/base_images/Dockerfile.python-3.11
@@ -1,5 +1,12 @@
 FROM python:3.11 AS base
 
+# When set, pre-install ddtrace from this URL (pip --find-links compatible).
+# Used by upstream dd-trace-py CI to test with just-built wheels.
+ARG DDTRACE_FIND_LINKS=""
+RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
+      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+    fi
+
 ENV DD_PROFILING_ENABLED=true
 ENV DD_TRACE_ENABLED=false
 ENV DD_TRACE_DEBUG=true

--- a/base_images/Dockerfile.python-3.11
+++ b/base_images/Dockerfile.python-3.11
@@ -1,10 +1,10 @@
 FROM python:3.11 AS base
 
-# When set, pre-install ddtrace from this URL (pip --find-links compatible).
-# Used by upstream dd-trace-py CI to test with just-built wheels.
-ARG DDTRACE_FIND_LINKS=""
-RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
-      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
     fi
 
 ENV DD_PROFILING_ENABLED=true

--- a/correctness_test.go
+++ b/correctness_test.go
@@ -105,8 +105,8 @@ func buildTestApp(t *testing.T, config DockerTestConfig) string {
 	now_time := time.Now()
 	// Following arg helps forces to rerun steps after the arg (allows reinstallation of recent profiler) --build-arg CACHE_DATE=$(date +%Y-%m-%d_%H:%M:%S)
 	args := []string{"build", "-f", config.dockerfilePath, "--build-arg", now_time.Format("2006-01-02_15:04:05"), "-t", "test-app"}
-	if fl := os.Getenv("DDTRACE_FIND_LINKS"); fl != "" {
-		args = append(args, "--build-arg", "DDTRACE_FIND_LINKS="+fl)
+	if u := os.Getenv("DDTRACE_INSTALL_URL"); u != "" {
+		args = append(args, "--build-arg", "DDTRACE_INSTALL_URL="+u)
 	}
 	args = append(args, ".")
 	cmd := exec.Command("docker", args...)
@@ -219,8 +219,8 @@ func buildBaseImage(rootDir string, baseImageName string, t *testing.T) {
 
 	tag := baseImageName
 	args := []string{"build", "-t", tag, "-f", dockerfilePath}
-	if fl := os.Getenv("DDTRACE_FIND_LINKS"); fl != "" {
-		args = append(args, "--build-arg", "DDTRACE_FIND_LINKS="+fl)
+	if u := os.Getenv("DDTRACE_INSTALL_URL"); u != "" {
+		args = append(args, "--build-arg", "DDTRACE_INSTALL_URL="+u)
 	}
 	args = append(args, rootDir)
 	buildCmd := exec.Command("docker", args...)

--- a/scenarios/python_cpu/Dockerfile
+++ b/scenarios/python_cpu/Dockerfile
@@ -1,6 +1,13 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11
 
+# When set, pre-install ddtrace from this URL (pip --find-links compatible).
+# Used by upstream dd-trace-py CI to test with just-built wheels.
+ARG DDTRACE_FIND_LINKS=""
+RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
+      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+    fi
+
 # Set the working directory in the container
 WORKDIR /usr/src/app
 

--- a/scenarios/python_cpu/Dockerfile
+++ b/scenarios/python_cpu/Dockerfile
@@ -1,12 +1,5 @@
-# Use an official Python runtime as a parent image
-FROM python:3.11
-
-# When set, download and run this install script to pre-install ddtrace.
-# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
-ARG DDTRACE_INSTALL_URL=""
-RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
-      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
-    fi
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
@@ -20,10 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ENV EXECUTION_TIME_SEC 30
 # Run your python script when the container launches
-ENV DD_PROFILING_ENABLED true
-ENV DD_TRACE_ENABLED false
-ENV DD_TRACE_DEBUG false
+ENV DD_TRACE_DEBUG=false
 ENV DD_PROFILING_MEMORY_ENABLED=false
-ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"
 
 CMD ddtrace-run python main.py

--- a/scenarios/python_cpu/Dockerfile
+++ b/scenarios/python_cpu/Dockerfile
@@ -1,11 +1,11 @@
 # Use an official Python runtime as a parent image
 FROM python:3.11
 
-# When set, pre-install ddtrace from this URL (pip --find-links compatible).
-# Used by upstream dd-trace-py CI to test with just-built wheels.
-ARG DDTRACE_FIND_LINKS=""
-RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
-      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
     fi
 
 # Set the working directory in the container

--- a/scenarios/python_pytorch_3.11/Dockerfile
+++ b/scenarios/python_pytorch_3.11/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.11
 
+# When set, pre-install ddtrace from this URL (pip --find-links compatible).
+# Used by upstream dd-trace-py CI to test with just-built wheels.
+ARG DDTRACE_FIND_LINKS=""
+RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
+      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+    fi
+
 WORKDIR /usr/src/app
 
 COPY ./scenarios/python_pytorch_3.11/ /usr/src/app

--- a/scenarios/python_pytorch_3.11/Dockerfile
+++ b/scenarios/python_pytorch_3.11/Dockerfile
@@ -1,11 +1,5 @@
-FROM python:3.11
-
-# When set, download and run this install script to pre-install ddtrace.
-# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
-ARG DDTRACE_INSTALL_URL=""
-RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
-      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
-    fi
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
 
 WORKDIR /usr/src/app
 
@@ -15,10 +9,7 @@ RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/wh
 RUN pip install --no-cache-dir -r requirements.txt
 
 ENV EXECUTION_TIME_SEC 30
-ENV DD_PROFILING_ENABLED true
-ENV DD_TRACE_ENABLED false
-ENV DD_TRACE_DEBUG false
+ENV DD_TRACE_DEBUG=false
 ENV DD_PROFILING_MEMORY_ENABLED=false
-ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"
 
 CMD ddtrace-run python main.py

--- a/scenarios/python_pytorch_3.11/Dockerfile
+++ b/scenarios/python_pytorch_3.11/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.11
 
-# When set, pre-install ddtrace from this URL (pip --find-links compatible).
-# Used by upstream dd-trace-py CI to test with just-built wheels.
-ARG DDTRACE_FIND_LINKS=""
-RUN if [ -n "$DDTRACE_FIND_LINKS" ]; then \
-      pip install --no-cache-dir --find-links "$DDTRACE_FIND_LINKS" --pre ddtrace; \
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
     fi
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
## What does this PR do?

https://github.com/DataDog/dd-trace-py/pull/16640

This PR updates prof-correctness to support triggering a downstream pipeline from `dd-trace-py` and passing a commit SHA to download wheels from S3 for, then running correctness checks against it. 

I have tested that manually triggering the workflow does the expected thing (run only Python checks, installing the right wheel).

Required follow-up/fix: https://github.com/DataDog/prof-correctness/pull/100