### PR TITLE
ci: fix `downstream-python.yml`

### DIFF
--- a/.github/workflows/downstream-python.yml
+++ b/.github/workflows/downstream-python.yml
@@ -19,5 +19,5 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       test_scenarios: ${{ inputs.test_scenarios }}
-      ddtrace_install_url: "https://dd-trace-py-builds.s3.amazonaws.com/${{ inputs.dd_trace_py_commit_sha }}/install-manylinux2014_x86_64.sh"
+      ddtrace_install_url: "https://dd-trace-py-builds.s3.amazonaws.com/${{ inputs.dd_trace_py_commit_sha }}/install.sh"
     secrets: inherit


### PR DESCRIPTION
## What is this PR about?

Turns out I made a mistake in #99, the URL it's using doesn't exist. 

This works: https://github.com/DataDog/prof-correctness/actions/runs/22355216486/job/64692829907.