### PR TITLE
[python_greenlet] Longer test, more slack

### DIFF
--- a/scenarios/python_greenlet_3.11/Dockerfile
+++ b/scenarios/python_greenlet_3.11/Dockerfile
@@ -16,7 +16,8 @@ ENV DD_PROFILING_ENABLED=true
 ENV DD_TRACE_ENABLED=false
 ENV DD_TRACE_DEBUG=false
 ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"
-ENV EXECUTION_TIME_SEC="4"
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
+ENV EXECUTION_TIME_SEC="8"
 
 # Run the program when the container starts
 CMD ddtrace-run python main.py

--- a/scenarios/python_greenlet_3.11/expected_profile.json
+++ b/scenarios/python_greenlet_3.11/expected_profile.json
@@ -10,7 +10,7 @@
         {
           "regular_expression": ".*work_a.*",
           "percent": 50,
-          "error_margin": 10,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -29,7 +29,7 @@
         {
           "regular_expression": ".*work_b.*",
           "percent": 50,
-          "error_margin": 10,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",


### PR DESCRIPTION
## What is this PR?

This PR makes the greenlet check longer to reduce noise and variance, disables adaptive sampling to avoid having CPU load / noisy neighbours affect the check, and adds some slack to the actual expected profile. 