### PR TITLE
[ci] Do not send message on downstream executions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         name: ${{ steps.artifact_name.outputs.name }}
         path: data
     - name: Notify Slack
-      if: failure() && github.ref == 'refs/heads/main'
+      if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
       run: |
         curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
              -H 'Content-Type: application/json' \


### PR DESCRIPTION
## What does this PR do?

This PR removes the message sending for downstream pipelines from `dd-trace-py`, it's a bit spammy right now.