### PR TITLE
Fix node profiling scenarios broken by dd-trace-js DD_TRACING_ENABLED change

### DIFF
--- a/scenarios/node_heap/Dockerfile
+++ b/scenarios/node_heap/Dockerfile
@@ -13,7 +13,16 @@ ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
 ENV DD_PROFILING_EXPORTERS=file
 ENV DD_PROFILING_ENABLED=1
 ENV DD_TRACING_ENABLED=0
+# TEMPORARY: Since dd-trace-js PR #6982, DD_TRACING_ENABLED=0 also disables the
+# entire tracer module (NoopProxy), which prevents the profiler from starting.
+# DD_DYNAMIC_INSTRUMENTATION_ENABLED=true is on the allowlist (added in PR #7916)
+# that keeps the real proxy alive while tracing stays off. Remove once dd-trace-js
+# adds DD_PROFILING_ENABLED to that allowlist.
+ENV DD_DYNAMIC_INSTRUMENTATION_ENABLED=true
 ENV DD_REMOTE_CONFIGURATION_ENABLED=0
+# Disable telemetry so its beforeExit HTTP request doesn't allocate thousands
+# of objects that dominate the heap snapshot and skew percentage assertions.
+ENV DD_INSTRUMENTATION_TELEMETRY_ENABLED=false
 ENV DD_PROFILING_PROFILERS=space
 ENV DD_TRACE_DEBUG=1
 CMD node --expose-gc -r dd-trace/init main.js

--- a/scenarios/node_heap_oom/Dockerfile
+++ b/scenarios/node_heap_oom/Dockerfile
@@ -13,7 +13,16 @@ ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
 ENV DD_PROFILING_EXPORTERS=file
 ENV DD_PROFILING_ENABLED=1
 ENV DD_TRACING_ENABLED=0
+# TEMPORARY: Since dd-trace-js PR #6982, DD_TRACING_ENABLED=0 also disables the
+# entire tracer module (NoopProxy), which prevents the profiler from starting.
+# DD_DYNAMIC_INSTRUMENTATION_ENABLED=true is on the allowlist (added in PR #7916)
+# that keeps the real proxy alive while tracing stays off. Remove once dd-trace-js
+# adds DD_PROFILING_ENABLED to that allowlist.
+ENV DD_DYNAMIC_INSTRUMENTATION_ENABLED=true
 ENV DD_REMOTE_CONFIGURATION_ENABLED=0
+# Disable telemetry so its beforeExit HTTP request doesn't allocate thousands
+# of objects that dominate the heap snapshot and skew percentage assertions.
+ENV DD_INSTRUMENTATION_TELEMETRY_ENABLED=false
 ENV DD_PROFILING_PROFILERS=space
 ENV DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED=1
 ENV DD_TRACE_DEBUG=1

--- a/scenarios/node_wall_cpu/Dockerfile
+++ b/scenarios/node_wall_cpu/Dockerfile
@@ -13,7 +13,16 @@ ENV DD_PROFILING_PPROF_PREFIX="/app/data/profiles_"
 ENV DD_PROFILING_EXPORTERS=file
 ENV DD_PROFILING_ENABLED=1
 ENV DD_TRACING_ENABLED=0
+# TEMPORARY: Since dd-trace-js PR #6982, DD_TRACING_ENABLED=0 also disables the
+# entire tracer module (NoopProxy), which prevents the profiler from starting.
+# DD_DYNAMIC_INSTRUMENTATION_ENABLED=true is on the allowlist (added in PR #7916)
+# that keeps the real proxy alive while tracing stays off. Remove once dd-trace-js
+# adds DD_PROFILING_ENABLED to that allowlist.
+ENV DD_DYNAMIC_INSTRUMENTATION_ENABLED=true
 ENV DD_REMOTE_CONFIGURATION_ENABLED=0
+# Disable telemetry so its beforeExit HTTP request doesn't allocate objects
+# that contaminate the profiles and skew percentage assertions.
+ENV DD_INSTRUMENTATION_TELEMETRY_ENABLED=false
 ENV DD_PROFILING_PROFILERS=wall
 ENV DD_PROFILING_EXPERIMENTAL_CPU_ENABLED=1
 ENV DD_TRACE_DEBUG=1


### PR DESCRIPTION
## Summary

The nightly node CI job has been failing on `node_heap`, `node_heap_oom`, and `node_wall_cpu` with `No matching files found for *.pprof` — no profile files were being produced at all. Root-caused to dd-trace-js [PR #6982](https://github.com/DataDog/dd-trace-js/pull/6982) (commit `a995feed41`, merged 2026-01-22), which switched the `DD_TRACE_ENABLED` lookup in `packages/dd-trace/src/index.js` from `getEnvironmentVariable` to `getValueFromEnvSources`. The new helper resolves aliases, so `DD_TRACING_ENABLED=0` (declared as an alias of `DD_TRACE_ENABLED` in `supported-configurations.json`) now flips the package export to `NoopProxy` — which means the profiler never starts.

Fix:
- Add `DD_DYNAMIC_INSTRUMENTATION_ENABLED=true` to keep the real proxy alive (it's on the allowlist added in [PR #7916](https://github.com/DataDog/dd-trace-js/pull/7916)) while leaving tracing off. Marked `TEMPORARY` in the comment — the proper upstream fix is to add `DD_PROFILING_ENABLED` to that same allowlist.
- Add `DD_INSTRUMENTATION_TELEMETRY_ENABLED=false`. With the tracer module now loaded, the telemetry `beforeExit` handler fires a final HTTP request whose setup allocates thousands of small objects that dominated the heap snapshot — `node_heap`'s `objects/count` profile was 98% telemetry stacks, and `node_heap_oom`'s `space` percentage drifted just outside the ±3% margin (93% vs expected 97%).

## Test plan

- [x] `TEST_SCENARIOS='node_(heap|heap_oom|wall_cpu)$' go test -timeout 10m -v -run TestScenarios` passes locally for all three scenarios
- [x] `node_code_hotspots` (unchanged) still passes
- [ ] Verify in nightly CI run after merge