### PR TITLE
Add cmd/prof-analyze CLI for cross-platform analyzer invocation

### DIFF
--- a/cmd/prof-analyze/main.go
+++ b/cmd/prof-analyze/main.go
@@ -1,0 +1,43 @@
+// prof-analyze runs the prof-correctness analyzer on a directory of pprof
+// files against an expected_profile.json description, and exits non-zero if
+// any assertion fails. It's the cross-platform CLI counterpart to the
+// `TestAnalyze` test entry point — meant for use from external repos
+// (e.g. dd-win-prof on Windows) via `go install`.
+//
+// Exit codes:
+//   0  all assertions passed
+//   1  one or more assertions failed
+//   2  usage error (missing/invalid flags)
+//
+// Usage:
+//
+//	prof-analyze -expectedJson expected_profile.json -pprofPath ./out
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/profiler-correctness/v1/analysis"
+)
+
+func main() {
+	expectedJSON := flag.String("expectedJson", "", "Path to the expected_profile.json file (required)")
+	pprofPath := flag.String("pprofPath", "", "Path to the directory containing pprof files (required)")
+	flag.Parse()
+
+	if *expectedJSON == "" || *pprofPath == "" {
+		fmt.Fprintln(os.Stderr, "prof-analyze: -expectedJson and -pprofPath are required")
+		flag.PrintDefaults()
+		os.Exit(2)
+	}
+
+	r := analysis.NewStdReporter(os.Stdout, os.Stderr)
+	analysis.Run(r, func() {
+		analysis.AnalyzeResults(r, *expectedJSON, *pprofPath)
+	})
+	if r.Failed() {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
Adds a tiny CLI (`cmd/prof-analyze`) that wraps `analysis.AnalyzeResults` + `StdReporter` + `Run()`. Lets external repos invoke the analyzer with a plain `go install` instead of building Go test infrastructure of their own.

```sh
go install github.com/DataDog/profiler-correctness/v1/cmd/prof-analyze@<ref>
prof-analyze -expectedJson expected_profile.json -pprofPath ./out
```

## Why
First downstream consumer is `dd-win-prof` on Windows — it can't use the Docker-based `analyze/` GitHub Action (Linux-only), and we'd rather not duplicate analyzer wiring in every consuming repo. Other Datadog profilers can use the same install path.

## Design notes
- Flag names match the existing `TestAnalyze` entry point (`-expectedJson` / `-pprofPath`) so callers can swap between `go test -run TestAnalyze ...` and `prof-analyze ...` without changing arguments.
- Three exit codes: `0` success, `1` assertion failure (or fatal like missing file), `2` usage error.
- No new dependencies, no schema changes, no behavior changes to the existing analyzer or the Docker action.

## Test plan
- [x] `go build ./cmd/prof-analyze`
- [x] `go vet ./...`
- [x] Smoke: happy-path JSON → exit 0
- [x] Smoke: value-mismatch JSON → exit 1, prints failed assertion
- [x] Smoke: missing flags → exit 2, prints usage
- [x] Smoke: nonexistent expected JSON → exit 1 (Fatalf via `Run` recovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)