### PR TITLE
[python_spiky] Add new check

### DIFF
--- a/scenarios/python_spiky_3.11/Dockerfile
+++ b/scenarios/python_spiky_3.11/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_spiky_3.11/main.py \
+    ./scenarios/python_spiky_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="20"
+
+# Leave empty to use ddtrace defaults.
+# _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_TARGET_OVERHEAD controls the fraction of
+# CPU (0-100) the profiler is allowed to consume; lower means sparser sampling.
+# _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US is the hard upper bound
+# on the interval between stack samples in microseconds; higher means sparser sampling.
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_TARGET_OVERHEAD="1"
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="10000"
+
+CMD python main.py

--- a/scenarios/python_spiky_3.11/README.md
+++ b/scenarios/python_spiky_3.11/README.md
@@ -1,0 +1,12 @@
+# python_spiky_3.11
+
+Verifies that the Python profiler correctly distinguishes CPU-time from wall-time when a process mixes on-CPU work and `time.sleep`.
+
+Two threads run concurrently for the same duration:
+- **MainThread**: burns CPU with `math.factorial` (on-CPU work)
+- **Thread-1**: loops over `time.sleep` (off-CPU/sleeping)
+
+## Expected behavior
+
+- **wall-time**: both threads contribute ~50% each, since both run for the same duration
+- **cpu-time**: only `cpu_work` appears (~90%+), since sleeping does not consume CPU

--- a/scenarios/python_spiky_3.11/expected_profile.json
+++ b/scenarios/python_spiky_3.11/expected_profile.json
@@ -1,0 +1,31 @@
+{
+  "test_name": "python_spiky",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*cpu_spike",
+          "percent": 50,
+          "error_margin": 10
+        },
+        {
+          "regular_expression": ".*sleep_period",
+          "percent": 50,
+          "error_margin": 10
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*cpu_spike",
+          "percent": 90,
+          "error_margin": 10
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_spiky_3.11/main.py
+++ b/scenarios/python_spiky_3.11/main.py
@@ -1,0 +1,51 @@
+import math
+import os
+import random
+from itertools import zip_longest
+from time import sleep, time
+
+from ddtrace.profiling import Profiler
+
+
+def cpu_spike(duration: float) -> None:
+    end = time() + duration
+    while time() < end:
+        math.factorial(50000)
+
+
+def sleep_period(duration: float) -> None:
+    sleep(duration)
+
+
+def _generate_durations(total: float, min_dur: float, max_dur: float) -> list[float]:
+    """Return durations drawn from [min_dur, max_dur] that sum exactly to total."""
+    durations: list[float] = []
+    remaining = total
+    while remaining > min_dur:
+        d = random.uniform(min_dur, min(max_dur, remaining))  # noqa: S311
+        durations.append(d)
+        remaining -= d
+    if remaining > 0:
+        durations.append(remaining)
+    return durations
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "20"))
+    # Split evenly so the cpu/wall-time percentages are a fixed, predictable 50/50.
+    half = execution_time / 2.0
+
+    # Precompute durations whose sums are exactly `half` each.  Individual
+    # spike lengths are random but the totals are deterministic, so the
+    # expected-profile percentages hold regardless of how the randomness plays out.
+    cpu_durations = _generate_durations(half, 0.5, 1.5)
+    sleep_durations = _generate_durations(half, 0.8, 1.2)
+
+    for cpu_dur, sleep_dur in zip_longest(cpu_durations, sleep_durations):
+        if cpu_dur is not None:
+            cpu_spike(cpu_dur)
+        if sleep_dur is not None:
+            sleep_period(sleep_dur)

--- a/scenarios/python_spiky_3.11/requirements.txt
+++ b/scenarios/python_spiky_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a new `python_spiky` correctness check for Python, whose goal is to assess whether our sampling strategy works well on spiky workloads. 

Such workloads are typically problematic for our current adaptive sampling strategy: every time we capture a sample, we compute the amount of CPU time consumed to capture it, then compare it to the total CPU time consumed by the process since the previous sample. We then adjust the sampling interval to stay under a predefined target (e.g. 1%). 

The problem with this approach is that it doesn't work well for idle workloads (1% of ~0 is even closer to 0), so the sampling interval quickly converges to what we allow for its maximum: one second. The problem with this is that taking one sample per second and making a flame graph out of it doesn't really make any sense.

This adaptive sampling strategy also falls short on non-idle workloads when they are spiky (which is the case of several Python services we have internally). Because it is reactive to CPU use (or non use), we end up most of the time under-sampling the interesting bits (on-CPU time) and over-sampling uninteresting bits that come right after (off-CPU time).  
The reason for that is that we compute the next sampling interval based on what happened during the previous interval. If the previous interval is idle but the next is going to be on-CPU, we'll miss what happens next. If the previous interval was on-CPU but the next is idle, we have missed the interesting part and are going to heavily sample the boring part that comes next. 

We are implementing improvements to our strategy in dd-trace-py to work around this (see https://github.com/DataDog/dd-trace-py/pull/18332 for example), and the goal is to have a robust framework to evaluate what comes out of it, on code that we know what the ground truth for should be. 