### PR TITLE
fix: properly pass `--rm` for test containers

### DIFF
--- a/docker_helpers_test.go
+++ b/docker_helpers_test.go
@@ -195,12 +195,12 @@ func runTestAppSafe(dockerTag string, folder string) (string, error) {
 
 	var args []string
 	if strings.Contains(folder, "full_host") {
-		args = []string{"run", "-v", mountOption, "--pid=host", "--privileged", "--security-opt", "seccomp=unconfined"}
+		args = []string{"run", "--rm", "-v", mountOption, "--pid=host", "--privileged", "--security-opt", "seccomp=unconfined"}
 		args = append(args, "--cap-add=SYS_ADMIN", "--cap-add=SYS_PTRACE", "--cap-add=SYS_RESOURCE")
 		args = append(args, "-v", "/sys/kernel/debug:/sys/kernel/debug:ro")
 		args = append(args, "-v", "/sys/kernel/tracing:/sys/kernel/tracing:ro")
 	} else {
-		args = []string{"run", "-v", mountOption, "-u", userOption, "--security-opt", "seccomp=unconfined"}
+		args = []string{"run", "--rm", "-v", mountOption, "-u", userOption, "--security-opt", "seccomp=unconfined"}
 	}
 
 	if DURATION_SET {


### PR DESCRIPTION
## What is this PR?

Currently, test containers created through `prof-correctness` live on forever even after exiting and really accumulate over time. Passing `--rm` will remove them after they finish executing. 


<img width="967" height="417" alt="image" src="https://github.com/user-attachments/assets/e127e3f3-b7cc-46ae-889c-305c7ef47570" />


