### PR TITLE
[python_cpu_sleep_sync_3.12] add CPU/sleep attribution scenario (PROF-14213)

### DIFF
--- a/base_images/Dockerfile.python-3.12
+++ b/base_images/Dockerfile.python-3.12
@@ -1,0 +1,10 @@
+FROM python:3.12 AS base
+
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
+    fi
+
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=false
+ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"

--- a/base_images/Dockerfile.python-3.12
+++ b/base_images/Dockerfile.python-3.12
@@ -1,5 +1,7 @@
 FROM python:3.12 AS base
 
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
 ARG DDTRACE_INSTALL_URL=""
 RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
       curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
@@ -7,4 +9,5 @@ RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
 
 ENV DD_PROFILING_ENABLED=true
 ENV DD_TRACE_ENABLED=false
+# ENV DD_TRACE_DEBUG=true
 ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"

--- a/scenarios/python_cpu_sleep_sync_3.12/Dockerfile
+++ b/scenarios/python_cpu_sleep_sync_3.12/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE="prof-python-3.12"
+FROM $BASE_IMAGE
+
+WORKDIR /usr/src/app
+
+COPY ./scenarios/python_cpu_sleep_sync_3.12/ /usr/src/app
+
+RUN chmod 644 /usr/src/app/main.py
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=30
+ENV DD_PROFILING_MEMORY_ENABLED=false
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
+
+CMD ddtrace-run python main.py

--- a/scenarios/python_cpu_sleep_sync_3.12/expected_profile.json
+++ b/scenarios/python_cpu_sleep_sync_3.12/expected_profile.json
@@ -1,0 +1,21 @@
+{
+  "test_name": "python_cpu_sleep_sync_3.12",
+  "scale_by_duration": true,
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*",
+          "value": 167000000,
+          "error_margin": 25
+        },
+        {
+          "regular_expression": ".*cpu_burst.*",
+          "percent": 50,
+          "error_margin": 15
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_cpu_sleep_sync_3.12/main.py
+++ b/scenarios/python_cpu_sleep_sync_3.12/main.py
@@ -1,0 +1,24 @@
+import os
+import time
+
+
+def cpu_burst(target_seconds: float) -> int:
+    deadline = time.monotonic() + target_seconds
+    x = 0x1234
+    while time.monotonic() < deadline:
+        x = (x * 48271) % 2147483647
+    return x
+
+
+def main() -> None:
+    execution_time_sec = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    cpu_seconds = 0.01
+    off_cpu = 0.05
+    deadline = time.monotonic() + execution_time_sec
+    while time.monotonic() < deadline:
+        time.sleep(off_cpu)
+        cpu_burst(cpu_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/python_cpu_sleep_sync_3.12/requirements.txt
+++ b/scenarios/python_cpu_sleep_sync_3.12/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## Summary

- New prof-correctness scenario `python_cpu_sleep_sync_3.12` exercising CPU + sleep alternation in sync mode on Python 3.12.
- Asserts both total CPU (167M ns/wall-sec, ±25%) and `cpu_burst` self-attribution (50%, ±15%).
- Adds `base_images/Dockerfile.python-3.12` (also added by the sibling asyncio + gevent PRs; rebase whichever lands second/third).

## Why Python 3.12

Python 3.12 is the most widely deployed version among dd-trace-py customers and the version Datadog runs internally, so the regression check exercises the same combination most users see in production.

## Why these bounds

Based on the python-cpu-accuracy survey (DataDog/experimental, users/taegyun.kim/python-cpu-accuracy). Sync mode with 10 ms / 50 ms parameters hits the architectural ~50% attribution ceiling described in Finding 2 — the bound codifies that ceiling as a regression check. Total CPU is governed by the formula M × C / (C + S) = 1 × 0.01 / 0.06 = 0.167 CPU-sec/wall-sec.

Local run:
- '.*' (total CPU): expected 5.0e+09 ns, actual 5_156_792_000 (2.3% error)
- '.*cpu_burst.*' (attribution): expected 50%, actual 48% (2% error)

## Test plan

- [ ] TEST_SCENARIOS="python_cpu_sleep_sync_3.12" go test -timeout 10m -v -run TestScenarios passes locally
- [ ] CI python.* job passes

JIRA: PROF-14213