### PR TITLE
[python_cpu_sleep_gevent_3.12] add CPU/sleep attribution scenario (PROF-14213)

### DIFF
--- a/base_images/Dockerfile.python-3.12
+++ b/base_images/Dockerfile.python-3.12
@@ -1,0 +1,13 @@
+FROM python:3.12 AS base
+
+# When set, download and run this install script to pre-install ddtrace.
+# Used by upstream dd-trace-py CI to test with just-built wheels from S3.
+ARG DDTRACE_INSTALL_URL=""
+RUN if [ -n "$DDTRACE_INSTALL_URL" ]; then \
+      curl -fsSL "$DDTRACE_INSTALL_URL" | bash; \
+    fi
+
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=false
+# ENV DD_TRACE_DEBUG=true
+ENV DD_PROFILING_OUTPUT_PPROF="/app/data/profiles"

--- a/scenarios/python_cpu_sleep_gevent_3.12/Dockerfile
+++ b/scenarios/python_cpu_sleep_gevent_3.12/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE="prof-python-3.12"
+FROM $BASE_IMAGE
+
+WORKDIR /usr/src/app
+
+COPY ./scenarios/python_cpu_sleep_gevent_3.12/ /usr/src/app
+
+RUN chmod 644 /usr/src/app/main.py
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=30
+ENV DD_PROFILING_MEMORY_ENABLED=false
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=0
+
+CMD ddtrace-run python main.py

--- a/scenarios/python_cpu_sleep_gevent_3.12/expected_profile.json
+++ b/scenarios/python_cpu_sleep_gevent_3.12/expected_profile.json
@@ -1,0 +1,21 @@
+{
+  "test_name": "python_cpu_sleep_gevent_3.12",
+  "scale_by_duration": true,
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*",
+          "value": 667000000,
+          "error_margin": 25
+        },
+        {
+          "regular_expression": ".*cpu_burst.*",
+          "percent": 80,
+          "error_margin": 10
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_cpu_sleep_gevent_3.12/main.py
+++ b/scenarios/python_cpu_sleep_gevent_3.12/main.py
@@ -1,0 +1,42 @@
+from gevent import monkey
+
+monkey.patch_all()
+
+import os  # noqa: E402
+import time  # noqa: E402
+
+import gevent  # noqa: E402
+
+
+def cpu_burst(target_seconds: float) -> int:
+    deadline = time.monotonic() + target_seconds
+    x = 0x1234
+    while time.monotonic() < deadline:
+        x = (x * 48271) % 2147483647
+    return x
+
+
+def slot(cpu_seconds: float, off_cpu: float, deadline: float) -> None:
+    while time.monotonic() < deadline:
+        time.sleep(off_cpu)
+        cpu_burst(cpu_seconds)
+
+
+def main() -> None:
+    execution_time_sec = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    cpu_seconds = 0.01
+    off_cpu = 0.05
+    concurrency = 4
+    stagger = 0.01
+
+    deadline = time.monotonic() + execution_time_sec
+    greenlets = []
+    for i in range(concurrency):
+        if i > 0:
+            gevent.sleep(stagger)
+        greenlets.append(gevent.spawn(slot, cpu_seconds, off_cpu, deadline))
+    gevent.joinall(greenlets)
+
+
+if __name__ == "__main__":
+    main()

--- a/scenarios/python_cpu_sleep_gevent_3.12/requirements.txt
+++ b/scenarios/python_cpu_sleep_gevent_3.12/requirements.txt
@@ -1,0 +1,2 @@
+ddtrace
+gevent>=24.0


### PR DESCRIPTION
## ⚠️ Blocked on dd-trace-py 4.10.0 release

This scenario regression-tests the fix in [dd-trace-py PR #18222](https://github.com/DataDog/dd-trace-py/pull/18222) (`fix(profiling): swap on-CPU greenlet to position 0 in unwind_greenlets`). That fix is merged into `dd-trace-py/main` but **is not in any released ddtrace tag** (latest release is `4.9.0`; the fix landed after `4.10.0rc1` was tagged). Until `4.10.0` ships to PyPI, this scenario will fail in CI by ~1.6× total-CPU over-count.

**Do not merge this PR until `ddtrace==4.10.0` (or any release that contains PR #18222) is on PyPI** — merging earlier will break the prof-correctness CI on main and page #profiling-library-pager on every scheduled run.

Track via `pip index versions ddtrace --pre` or by checking that `git tag --contains 0c96beab64` (in dd-trace-py) lists a release tag.

## Summary

- New prof-correctness scenario `python_cpu_sleep_gevent_3.12` exercising CPU + sleep alternation in gevent mode (M=4 staggered greenlets) on Python 3.12.
- Asserts both total CPU (667M ns/wall-sec, ±25%) and `cpu_burst` self-attribution (80%, ±10%).
- Acts as a regression check for the gevent over-count bug fixed by dd-trace-py PR #18222 — if it recurs (or ships unreleased), total CPU inflates ~1.6× and busts the ±25% margin.
- Adds `base_images/Dockerfile.python-3.12` (also added by the sibling sync + asyncio PRs; rebase whichever lands second/third).

## Why Python 3.12

Python 3.12 is the most widely deployed version among dd-trace-py customers and the version Datadog runs internally, so the regression check exercises the same combination most users see in production.

## Why these bounds

Based on the python-cpu-accuracy survey (DataDog/experimental, users/taegyun.kim/python-cpu-accuracy) adaptive-off gevent run after PR #18222. Same formula as asyncio: M × C / (C + S) = 4 × 0.01 / 0.06 = 0.667 CPU-sec/wall-sec, with `_cpu_loop` self-time at ~82% in the survey.

## Current local-run result (pre-4.10.0 release)

Confirms the regression check fires correctly:
- `.*` (total CPU): expected 2.03e+10 ns, actual 32_894_377_000 ns (~62% over) — bug present
- `.*cpu_burst.*` (attribution): expected 80%, actual 52% — bug present

These numbers will swing to ≤5% error on both metrics once `ddtrace==4.10.0` is released and CI picks it up.

## Test plan

- [ ] `TEST_SCENARIOS="python_cpu_sleep_gevent_3.12" go test -timeout 10m -v -run TestScenarios` passes locally (currently fails — blocked on 4.10.0)
- [ ] CI `python.*` job passes (currently fails — blocked on 4.10.0)
- [ ] After `ddtrace==4.10.0` is on PyPI, verify CI green and re-request review

JIRA: PROF-14213