### PR TITLE
[python_safe_point_bias] Add new check

### DIFF
--- a/scenarios/python_safe_point_bias_3.11/Dockerfile
+++ b/scenarios/python_safe_point_bias_3.11/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+WORKDIR /usr/src/app
+
+COPY ./scenarios/python_safe_point_bias_3.11/ /usr/src/app
+
+RUN chmod 644 /usr/src/app/main.py
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=20
+ENV DD_TRACE_DEBUG=false
+ENV DD_PROFILING_MEMORY_ENABLED=false
+
+CMD ddtrace-run python main.py

--- a/scenarios/python_safe_point_bias_3.11/README.md
+++ b/scenarios/python_safe_point_bias_3.11/README.md
@@ -1,0 +1,25 @@
+# python_safe_point_bias_3.11
+
+Verifies that the Python profiler correctly attributes CPU time to `slow_method` rather than to `empty_method`, which is called from `slow_method` but does no work.
+
+## What the program does
+
+`slow_method` performs string concatenations and then calls `empty_method`, which is a no-op. The loop runs for the full `EXECUTION_TIME_SEC` duration.
+
+```python
+def empty_method() -> None:
+    pass
+
+def slow_method() -> None:
+    while time() < end_time:
+        x = "h" + "e" + "l" + "l" + "o" + ","
+        x += "w" + "o" + "r" + "l" + "d"
+        empty_method()
+```
+
+## Expected behavior
+
+- **cpu-time**: `slow_method` appears in ~100% of samples (inclusive), since all CPU work happens there.
+- **cpu-time**: `empty_method` appears in ~0% of samples; it is a no-op and should not be blamed for the CPU usage of its caller.
+
+A profiler with a blame-attribution bug would incorrectly show `empty_method` consuming significant CPU time.

--- a/scenarios/python_safe_point_bias_3.11/expected_profile.json
+++ b/scenarios/python_safe_point_bias_3.11/expected_profile.json
@@ -1,0 +1,21 @@
+{
+  "test_name": "python_safe_point_bias",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*slow_method",
+          "percent": 100,
+          "error_margin": 5
+        },
+        {
+          "regular_expression": ".*empty_method",
+          "percent": 0,
+          "error_margin": 5
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_safe_point_bias_3.11/main.py
+++ b/scenarios/python_safe_point_bias_3.11/main.py
@@ -1,0 +1,19 @@
+import os
+from time import time
+
+
+def empty_method() -> None:
+    pass
+
+
+def slow_method() -> None:
+    execution_time_sec = float(os.getenv("EXECUTION_TIME_SEC", "10"))
+    end = time() + execution_time_sec
+    while time() < end:
+        x = "h" + "e" + "l" + "l" + "o" + ","
+        x += "w" + "o" + "r" + "l" + "d"
+        empty_method()
+
+
+if __name__ == "__main__":
+    slow_method()

--- a/scenarios/python_safe_point_bias_3.11/requirements.txt
+++ b/scenarios/python_safe_point_bias_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a check against "safe point bias" in Python derived from @ivoanjo's [presentation](https://docs.google.com/presentation/d/1n6spoj8K2srGdmcPpXAiUT2f2RBO9ayhfgT8brxBcnk/edit?slide=id.g3ae87565b56_0_32#slide=id.g3ae87565b56_0_32).

Currently it is _not_ failing and it should not start failing in the future: `slow_method` takes 100% and `empty_method` takes 0%. 

Note that the `empty_method` does get some CPU time attributed to it but as far as I know, this is not safe point bias. It's just that calling a method in Python does take time and just getting into and out of it is sufficiently costly that we do see the thread be in that function from time to time. Hence the non-zero percent.