### PR TITLE
[python_deep_stack] Add new check

### DIFF
--- a/scenarios/python_deep_stack_3.11/Dockerfile
+++ b/scenarios/python_deep_stack_3.11/Dockerfile
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_deep_stack_3.11/main.py \
+    ./scenarios/python_deep_stack_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="10"
+
+ENV DD_PROFILING_ENABLED="true"
+
+CMD python main.py

--- a/scenarios/python_deep_stack_3.11/README.md
+++ b/scenarios/python_deep_stack_3.11/README.md
@@ -1,0 +1,18 @@
+# python_deep_stack_3.11
+
+Verifies that the stack unwinder correctly captures deep call stacks. Every
+other scenario has shallow stacks (fewer than ~10 frames), so the unwinder's
+depth loop, its cycle-detection guard, and the frame cache under hundreds of
+repeated identical frames are otherwise untested.
+
+The workload recurses 400 levels deep through `recurse` and then burns CPU in
+`burn` at the leaf for the full duration.
+
+## Expected behavior
+
+- **cpu-time**: nearly all CPU is attributed to a stack of the form
+  `<N frames omitted>;recurse;...;recurse;burn`. The exporter keeps only the
+  innermost ~64 frames and collapses the rest into a `<N frames omitted>`
+  marker, so the marker's presence (plus the dozens of retained consecutive
+  `recurse` frames ending in `burn`) proves the sampler walked the full deep
+  stack and counted the omitted frames.

--- a/scenarios/python_deep_stack_3.11/expected_profile.json
+++ b/scenarios/python_deep_stack_3.11/expected_profile.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "python_deep_stack",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": "[0-9]+ frames omitted\u003e;(recurse;){50,}burn",
+          "percent": 100,
+          "error_margin": 10
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_deep_stack_3.11/main.py
+++ b/scenarios/python_deep_stack_3.11/main.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from time import time
+
+from ddtrace.profiling import Profiler
+
+DEPTH = 400
+
+
+def burn(end: float) -> None:
+    x = 0
+    while time() < end:
+        for i in range(10000):
+            x += i
+
+
+def recurse(depth: int, end: float) -> None:
+    if depth <= 0:
+        burn(end)
+        return
+    recurse(depth - 1, end)
+
+
+if __name__ == "__main__":
+    sys.setrecursionlimit(10000)
+
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    end = time() + execution_time
+    recurse(DEPTH, end)

--- a/scenarios/python_deep_stack_3.11/requirements.txt
+++ b/scenarios/python_deep_stack_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a new correctness check. Its point is to make sure we properly unwind very deep call stacks (in that case 400 calls-deep), properly report the number of skipped frames, and properly attribute CPU and wall times to the stack. 