### PR TITLE
[python_many_threads] Add new check

### DIFF
--- a/scenarios/python_many_threads_3.11/Dockerfile
+++ b/scenarios/python_many_threads_3.11/Dockerfile
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_many_threads_3.11/main.py \
+    ./scenarios/python_many_threads_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="30"
+
+ENV DD_PROFILING_ENABLED="true"
+
+# Force reservoir sampling: there are 20 worker threads but at most 5 are
+# sampled per cycle, so the inverse-probability wall-time weighting must
+# reconstruct the correct totals.
+# We could go down to 1 or 2 but it makes the test very flaky. Even with
+# 5/20 sampling and 15% margin, the point is sufficiently proven.
+ENV _DD_PROFILING_STACK_MAX_THREADS="5"
+
+# Reservoir sampling with two threads results in very noisy wall time for
+# many threads. By reducing the interval, we get more samples and less noise.
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=1
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="10000"
+
+CMD python main.py

--- a/scenarios/python_many_threads_3.11/README.md
+++ b/scenarios/python_many_threads_3.11/README.md
@@ -1,0 +1,16 @@
+# python_many_threads_3.11
+
+Verifies that the stack sampler's reservoir sampling produces correct wall-time
+totals when the number of live threads exceeds the per-cycle sampling cap.
+
+The workload spawns 20 identical CPU-bound `worker` threads that all run for the
+full duration. `_DD_PROFILING_STACK_MAX_THREADS=2` forces the sampler to sample
+only 2 of the ~21 live threads each cycle (Algorithm R reservoir sampling),
+scaling each sampled thread's wall time by `n_total / sample_count`.
+
+## Expected behavior
+
+- **wall-time**: the combined wall time attributed to `worker` is ~20 cores
+  (one core-second per second per worker). Despite subsampling, the
+  inverse-probability weighting must reconstruct this total. This is the only
+  scenario that crosses the `max_threads` cap and exercises reservoir sampling.

--- a/scenarios/python_many_threads_3.11/expected_profile.json
+++ b/scenarios/python_many_threads_3.11/expected_profile.json
@@ -1,0 +1,326 @@
+{
+  "test_name": "python_many_threads",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-0"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-1"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-2"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-3"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-4"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-5"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-6"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-7"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+                "values": ["worker-8"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-9"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-10"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-11"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-12"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-13"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-14"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-15"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-16"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-17"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-18"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*worker",
+          "value": 1000000000,
+          "error_margin": 10,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["worker-19"]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_many_threads_3.11/main.py
+++ b/scenarios/python_many_threads_3.11/main.py
@@ -1,0 +1,30 @@
+import os
+import threading
+from time import time
+
+from ddtrace.profiling import Profiler
+
+NUM_WORKERS = 20
+
+
+def worker(end: float) -> None:
+    x = 0
+    while time() < end:
+        for i in range(10000):
+            x += i
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    end = time() + execution_time
+
+    threads: list[threading.Thread] = [
+        threading.Thread(target=worker, args=(end,), name=f"worker-{i}") for i in range(NUM_WORKERS)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()

--- a/scenarios/python_many_threads_3.11/requirements.txt
+++ b/scenarios/python_many_threads_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a new check `python_many_threads` which ensures the wall time resulting of reservoir sampling is the expected one. 

As a reminder, reservoir sampling picks, at each sampling event, `k` threads among `n` and captures samples for them. The default in dd-trace-py is `k=25` (which is more than enough for normal Python apps).   
To properly report wall time, reservoir sampling must multiply the wall time for the thread it sampled by `n / k`, such that statistically the wall time for the thread matches its actual wall time.

In this PR:
- We reduce the max number of threads sampled to 5
- We create 20 Threads doing random computations (so each time we capture a sample, 16 (15 workers + 1 main) threads actually don't get sampled)
- We ensure that each 20 Threads has a proper wall time reported (the duration of the check). 

Note that:
- The longer we run, the more likely we are to have the expected numbers. Running for less than 30 seconds doesn't yield great results.
- The more threads we sample, the more fidelity we have. Running with `k=3` makes the result way too noisy to be useful. `k=4` is still significant sampling while providing the expected output with little noise.
- A margin of less than `15%` makes the test flaky. 
