### PR TITLE
[python_gil_contention] Add new check

### DIFF
--- a/scenarios/python_gil_contention_3.11/Dockerfile
+++ b/scenarios/python_gil_contention_3.11/Dockerfile
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_gil_contention_3.11/main.py \
+    ./scenarios/python_gil_contention_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="30"
+
+ENV DD_PROFILING_ENABLED="true"
+
+CMD python main.py

--- a/scenarios/python_gil_contention_3.11/README.md
+++ b/scenarios/python_gil_contention_3.11/README.md
@@ -1,0 +1,18 @@
+# python_gil_contention_3.11
+
+Verifies the wall-vs-CPU relationship across many threads that are
+all runnable at once: wall time scales with the number of threads, but CPU time
+is bounded by the GIL to roughly one core.
+
+The workload runs 8 CPU-bound `spin` threads for the full duration. 8 is below
+the default `max_threads` cap, so every thread is sampled each cycle (no
+reservoir sampling, unlike `python_many_threads_3.11`).
+
+## Expected behavior
+
+- **cpu-time**: the combined CPU attributed to `spin` is ~1 core
+  (one core-second per second), because the GIL serializes Python bytecode
+  execution.
+- **wall-time**: the combined wall time attributed to `spin` is ~8 cores
+  (one core-second per second per thread), because all 8 threads are alive and
+  runnable for the whole run.

--- a/scenarios/python_gil_contention_3.11/expected_profile.json
+++ b/scenarios/python_gil_contention_3.11/expected_profile.json
@@ -1,0 +1,42 @@
+{
+  "test_name": "python_gil_contention",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 1000000000,
+          "error_margin": 5
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "percent": 12,
+          "error_margin": 6,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["spin-0"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 8000000000,
+          "error_margin": 5
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_gil_contention_3.11/main.py
+++ b/scenarios/python_gil_contention_3.11/main.py
@@ -1,0 +1,37 @@
+import os
+import threading
+import time
+
+from ddtrace.profiling import Profiler
+
+NUM_THREADS = 8
+NO_YIELD_TIME_MS = 100
+
+
+def spin(end: float) -> None:
+    x = 0
+    next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+    while time.time() < end:
+        for i in range(10_000):
+            x += i
+
+        # Help the scheduler yield to other threads
+        if time.time() > next_yield_time:
+            time.sleep(0.0001)
+            next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    end = time.time() + execution_time
+
+    threads: list[threading.Thread] = [
+        threading.Thread(target=spin, args=(end,), name=f"spin-{i}") for i in range(NUM_THREADS)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()

--- a/scenarios/python_gil_contention_3.11/requirements.txt
+++ b/scenarios/python_gil_contention_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a new Python correctness check, which ensures we see the right total CPU time when running 8 parallel CPU-bound threads. Since the GIL can only be held by one thread at a time, each thread should have approximately 12.5% of the total CPU time, the sum of CPU times across threads should be ~100% of the check run time, and the total wall time should be 8 x 100% of the check run time. 