### PR TITLE
ci: run docker-scenarios on ubuntu-8-core-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ on:
 
 jobs:
   docker-scenarios:
-    runs-on: ubuntu-latest
+    # Larger runner (dedicated VM per job) to reduce scheduling noise that
+    # skews profiler error margins.
+    runs-on: ubuntu-8-core-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Go


### PR DESCRIPTION
# Description

Move the `docker-scenarios` job to GitHub Larger Runners (`ubuntu-8-core-latest`, dedicated VM per job) to reduce scheduling/neighbour noise that inflates profiler assertion error margins.

This is consistent with what we are doing in dd-trace-doe.

# Motivation

We are trying to stabilize some wall clock checks for Python.
