### PR TITLE
[NO-TICKET] Pin ruby-spec to avoid breakages related to modern Rubies

### DIFF
--- a/scenarios/ruby_dir_interruption_patch/Dockerfile
+++ b/scenarios/ruby_dir_interruption_patch/Dockerfile
@@ -26,4 +26,4 @@ RUN chmod 777 /app/rubyspec_temp
 RUN useradd -u 1000 -ms /bin/bash someuser
 RUN useradd -u 1001 -ms /bin/bash someuser2
 
-CMD bundle exec ddprofrb exec ruby mspec-master/bin/mspec-run --config mspec_config.rb spec-master/core/dir/
+CMD bundle exec ddprofrb exec ruby mspec-master/bin/mspec-run --config mspec_config.rb spec-7240267784230e3e0bb9181dd4ea82216d136956/core/dir/

--- a/scenarios/ruby_dir_interruption_patch/Dockerfile
+++ b/scenarios/ruby_dir_interruption_patch/Dockerfile
@@ -9,9 +9,11 @@ RUN chmod 755 /app/*
 WORKDIR /app
 RUN bundle install
 
-RUN wget https://github.com/ruby/spec/archive/refs/heads/master.zip -O spec-master.zip
+# The `DirMonkeyPatch` issue does not affect Ruby 3.4+. We thus pin to this spec version, to avoid breakages from
+# ruby-spec changes for newer Rubies (and to avoid issues once ruby-spec drops 3.3 support).
+RUN wget https://github.com/ruby/spec/archive/7240267784230e3e0bb9181dd4ea82216d136956.zip -O spec.zip
 RUN wget https://github.com/ruby/mspec/archive/refs/heads/master.zip -O mspec-master.zip
-RUN unzip spec-master.zip
+RUN unzip spec.zip
 RUN unzip mspec-master.zip
 
 # Since we aggressively drop permissions when running, we need to manually create a folder for rubyspec to use

--- a/scenarios/ruby_dir_interruption_patch/Dockerfile
+++ b/scenarios/ruby_dir_interruption_patch/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /app
 RUN bundle install
 
 # The `DirMonkeyPatch` issue does not affect Ruby 3.4+. We thus pin to this spec version, to avoid breakages from
-# ruby-spec changes for newer Rubies (and to avoid issues once ruby-spec drops 3.3 support).
+# ruby-spec/mspec changes for newer Rubies (and to avoid issues once 3.3 support gets dropped).
 RUN wget https://github.com/ruby/spec/archive/7240267784230e3e0bb9181dd4ea82216d136956.zip -O spec.zip
-RUN wget https://github.com/ruby/mspec/archive/refs/heads/master.zip -O mspec-master.zip
+RUN wget https://github.com/ruby/mspec/archive/dffcdf7d00612c13465983224203e457a30cf124.zip -O mspec.zip
 RUN unzip spec.zip
-RUN unzip mspec-master.zip
+RUN unzip mspec.zip
 
 # Since we aggressively drop permissions when running, we need to manually create a folder for rubyspec to use
 RUN mkdir /app/rubyspec_temp
@@ -26,4 +26,4 @@ RUN chmod 777 /app/rubyspec_temp
 RUN useradd -u 1000 -ms /bin/bash someuser
 RUN useradd -u 1001 -ms /bin/bash someuser2
 
-CMD bundle exec ddprofrb exec ruby mspec-master/bin/mspec-run --config mspec_config.rb spec-7240267784230e3e0bb9181dd4ea82216d136956/core/dir/
+CMD bundle exec ddprofrb exec ruby mspec-dffcdf7d00612c13465983224203e457a30cf124/bin/mspec-run --config mspec_config.rb spec-7240267784230e3e0bb9181dd4ea82216d136956/core/dir/


### PR DESCRIPTION
**What does this PR do?**

This PR pins the version of `ruby-spec` used by the `ruby_dir_interruption_path` scenario to a known-good version.

This fixes the issue from
<https://github.com/DataDog/prof-correctness/actions/runs/26744158694/job/78815284046?pr=140>:

```
    correctness_test.go:31: Error running the test: docker run failed: exit status 1
        output: I, [2026-06-01T08:41:41.728271 #7]  INFO -- datadog: [datadog] DATADOG CONFIGURATION - CORE - {"date":"2026-06-01T08:41:41Z","os_name":"x86_64-pc-linux","version":"2.35.0.dev","lang":"ruby","lang_version":"3.3.11","env":null,"service":"prof-correctness-ruby_dir_interruption_patch","dd_version":null,"debug":false,"tags":null,"runtime_metrics_enabled":false,"vm":"ruby-3.3.11","health_metrics_enabled":false,"profiling_enabled":true,"dynamic_instrumentation_enabled":false}
        Dir interruption patch is present!
        ruby 3.3.11 (2026-03-26 revision 1f2d15125a) [x86_64-linux]
        ..........................................................................................................................................................................................................................................................................................................F................................

        1)
        Dir#pos is an alias of Dir#tell FAILED
        Expected #<UnboundMethod: Datadog::Profiling::Ext::DirInstanceMonkeyPatches#pos(*args, **kwargs, &block) /usr/local/bundle/bundler/gems/dd-trace-rb-d2be2410ee11/lib/datadog/profiling/ext/dir_monkey_patches.rb:418> == #<UnboundMethod: Datadog::Profiling::Ext::DirInstanceMonkeyPatches#tell(*args, **kwargs, &block) /usr/local/bundle/bundler/gems/dd-trace-rb-d2be2410ee11/lib/datadog/profiling/ext/dir_monkey_patches.rb:411>
        to be truthy but was false
        /app/spec-master/core/dir/pos_spec.rb:7:in `block (2 levels) in <top (required)>'
        /app/spec-master/core/dir/pos_spec.rb:5:in `<top (required)>'

        Finished in 0.900423 seconds

        34 files, 331 examples, 444 expectations, 1 failure, 0 errors, 0 tagged
```

This "issue" was caused by a ruby-spec change in
<https://github.com/ruby/spec/commit/8b6d6fd4e7ae43877bb19e951f3910a11243844f#diff-ecacfbabe71cb51153352e33560aeffdd9f76171b0efc48d421250dfebb5a0e3> but rather than trying to follow that change, we decided that it's easier to pin to a ruby-spec version that reflects 3.3, since anyway in the future ruby-spec is going to drop 3.3 and below.

**Motivation:**

Fix breakage in prof-correctness.

**Additional Notes:**

N/A

**How to test the change?**

CI should be green again!