### PR TITLE
[python_many_threads] Reduce noise in wall time

### DIFF
--- a/scenarios/python_many_threads/Dockerfile
+++ b/scenarios/python_many_threads/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 RUN pip install -r requirements.txt
 
-ENV EXECUTION_TIME_SEC="30"
+ENV EXECUTION_TIME_SEC="60"
 
 ENV DD_PROFILING_ENABLED="true"
 
@@ -25,5 +25,8 @@ ENV _DD_PROFILING_STACK_MAX_THREADS="5"
 # many threads. By reducing the interval, we get more samples and less noise.
 ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED=1
 ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="10000"
+
+# Make sure we don't upload around the one minute mark.
+ENV DD_PROFILING_UPLOAD_INTERVAL=120
 
 CMD python main.py

--- a/scenarios/python_many_threads/expected_profile.json
+++ b/scenarios/python_many_threads/expected_profile.json
@@ -7,7 +7,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -23,7 +23,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -39,7 +39,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -55,7 +55,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -71,7 +71,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -87,7 +87,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -103,7 +103,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -119,7 +119,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -135,7 +135,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -151,7 +151,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -167,7 +167,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -183,7 +183,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -199,7 +199,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -215,7 +215,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -231,7 +231,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -247,7 +247,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -263,7 +263,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -279,7 +279,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -295,7 +295,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",
@@ -311,7 +311,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 15,
           "labels": [
             {
               "key": "thread name",

--- a/scenarios/python_many_threads/expected_profile.json
+++ b/scenarios/python_many_threads/expected_profile.json
@@ -7,7 +7,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -23,7 +23,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -39,7 +39,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -55,7 +55,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -71,7 +71,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -87,7 +87,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -103,7 +103,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -119,7 +119,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -135,7 +135,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -151,7 +151,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -167,7 +167,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -183,7 +183,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -199,7 +199,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -215,7 +215,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -231,7 +231,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -247,7 +247,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -263,7 +263,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -279,7 +279,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -295,7 +295,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",
@@ -311,7 +311,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 15,
+          "error_margin": 5,
           "labels": [
             {
               "key": "thread name",

--- a/scenarios/python_many_threads/main.py
+++ b/scenarios/python_many_threads/main.py
@@ -19,18 +19,24 @@ def worker(barrier: threading.Barrier, end: float) -> None:
 
 if __name__ == "__main__":
     prof = Profiler()
-    prof.start()
 
     execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
     end = time() + execution_time
 
-    barrier = threading.Barrier(NUM_WORKERS)
+    barrier = threading.Barrier(NUM_WORKERS + 1)
     threads: list[threading.Thread] = [
         threading.Thread(target=worker, args=(barrier, end), name=f"worker-{i}") for i in range(NUM_WORKERS)
     ]
 
     for t in threads:
         t.start()
+
+    prof.start()
+
+    # Every worker is now alive and parked on the barrier, so the profiler has
+    # registered all 20 threads before any work begins. Release them together
+    # so no thread misses early sampling cycles.
+    barrier.wait()
 
     for t in threads:
         t.join()


### PR DESCRIPTION
## What is this PR?

After investigation, this PR changes the `python_many_threads` check to be more accurate in its results and less noisy (and thus flaky).
- Run the check for longer to reduce thread-starting noise 
- Start the Profiler after all threads are ready, making sure that there's no bias from certain threads existing earlier on
