### PR TITLE
reporter: ship per-assertion metrics to Datadog staging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,15 @@ jobs:
         # The matrix entry's regex is path-anchored (emitted by list-scenarios).
         TEST_SCENARIOS: ${{ matrix.regex }}
         DDTRACE_INSTALL_URL: ${{ inputs.ddtrace_install_url }}
+        # Ship per-assertion/per-scenario metrics to Datadog staging only for
+        # main-branch pushes and the nightly schedule. PR runs stay silent so
+        # they don't pollute the timeseries with branch noise.
+        DD_PROF_CORRECTNESS_REPORT: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' }}
+        DD_API_KEY_STAGING: ${{ secrets.DD_API_KEY_STAGING }}
+        DD_SITE: datad0g.com
+        RUNNER_LABEL: ubuntu-8-core-latest
+        GIT_REPO: ${{ github.repository }}
+        GIT_BRANCH: ${{ github.ref_name }}
     - name: Create unique artifact name
       id: artifact_name
       if: failure()

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -420,7 +420,7 @@ func checkLabels(r Reporter, labels map[string][]string, expectedLabels []Labels
 	return true
 }
 
-func assertStackWithFailureHandling(r Reporter, prof []StackSample, regexpStack string, valueOpt Optional[float64], pctOpt Optional[int64], epsilonPct int64, labels []Labels, allowFailure bool, hasFailures *bool) (matching int64) {
+func assertStackWithFailureHandling(r Reporter, prof []StackSample, regexpStack string, valueOpt Optional[float64], pctOpt Optional[int64], epsilonPct int64, labels []Labels, allowFailure bool, hasFailures *bool, profileType string, opts AnalyzeOptions) (matching int64) {
 	rx, err := regexp.Compile(regexpStack)
 	if err != nil {
 		r.Fatalf("Error compiling regex: %v, %s", err, regexpStack)
@@ -442,7 +442,8 @@ func assertStackWithFailureHandling(r Reporter, prof []StackSample, regexpStack 
 
 	if value, ok := valueOpt.Value(); ok {
 		errorPct := relDiff(float64(matching), value)
-		if errorPct > float64(epsilonPct) {
+		assertionPassed := errorPct <= float64(epsilonPct)
+		if !assertionPassed {
 			if allowFailure {
 				r.Logf("\033[33mAssertion failed (allowed): stack '%s' (labels=%v) should have been %.1f +/- %d%% of the profile but was %d with %.1f%% error\033[0m", regexpStack, labels, value, epsilonPct, matching, errorPct)
 				*hasFailures = true
@@ -452,11 +453,20 @@ func assertStackWithFailureHandling(r Reporter, prof []StackSample, regexpStack 
 		} else {
 			r.Logf("\033[32mAssertion succeeded: stack '%s' (labels=%v) is %.1f +/- %d%% of the profile (was %d with %.1f%% error)\033[0m", regexpStack, labels, value, epsilonPct, matching, errorPct)
 		}
+		if opts.Sink != nil {
+			opts.Sink.RecordAssertion(AssertionEvent{
+				Scenario: opts.Scenario, Language: opts.Language,
+				ProfileType: profileType, Kind: "value",
+				ErrorPct: errorPct, ErrorMargin: epsilonPct,
+				Passed: assertionPassed, AllowFailure: allowFailure,
+			})
+		}
 	}
 
 	if pct, ok := pctOpt.Value(); ok {
 		diff := absDiff(pct, actualPct)
-		if diff > epsilonPct {
+		assertionPassed := diff <= epsilonPct
+		if !assertionPassed {
 			if allowFailure {
 				r.Logf("\033[33mAssertion failed (allowed): stack '%s' (labels=%v) should have been %d%% +/- %d%% of the profile but was %d%% with %d%% error\033[0m", regexpStack, labels, pct, epsilonPct, actualPct, diff)
 				*hasFailures = true
@@ -466,11 +476,19 @@ func assertStackWithFailureHandling(r Reporter, prof []StackSample, regexpStack 
 		} else {
 			r.Logf("\033[32mAssertion succeeded: stack '%s' (labels=%v) is %d%% +/- %d%% of the profile (was %d%% with %d%% error)\033[0m", regexpStack, labels, pct, epsilonPct, actualPct, diff)
 		}
+		if opts.Sink != nil {
+			opts.Sink.RecordAssertion(AssertionEvent{
+				Scenario: opts.Scenario, Language: opts.Language,
+				ProfileType: profileType, Kind: "percent",
+				ErrorPct: float64(diff), ErrorMargin: epsilonPct,
+				Passed: assertionPassed, AllowFailure: allowFailure,
+			})
+		}
 	}
 	return
 }
 
-func analyzeProfDataWithFailureHandling(r Reporter, prof []StackSample, typedStacks TypedStacks, durationSecs float64, allowFailure bool) {
+func analyzeProfDataWithFailureHandling(r Reporter, prof []StackSample, typedStacks TypedStacks, durationSecs float64, allowFailure bool, opts AnalyzeOptions) {
 	var matchingSum int64 = 0
 	var hasFailures bool = false
 
@@ -489,7 +507,7 @@ func analyzeProfDataWithFailureHandling(r Reporter, prof []StackSample, typedSta
 			errorMargin = stackErrorMargin
 		}
 
-		matching := assertStackWithFailureHandling(r, prof, regexpStack, valueOpt, percent, errorMargin, stack.Labels, allowFailure, &hasFailures)
+		matching := assertStackWithFailureHandling(r, prof, regexpStack, valueOpt, percent, errorMargin, stack.Labels, allowFailure, &hasFailures, typedStacks.ProfileType, opts)
 		matchingSum += matching
 		// TODO: add an assertion on counts (e.g. number of allocations), not just summed values.
 	}
@@ -501,7 +519,8 @@ func analyzeProfDataWithFailureHandling(r Reporter, prof []StackSample, typedSta
 			value = value * durationSecs
 		}
 		errorPct := relDiff(float64(matchingSum), value)
-		if errorPct > float64(typedStacks.ErrorMargin) {
+		assertionPassed := errorPct <= float64(typedStacks.ErrorMargin)
+		if !assertionPassed {
 			if allowFailure {
 				r.Logf("\033[33mAssertion failed (allowed): profile '%s' should have total matching sum of %1.f +/- %d%% but was %d with %.1f%% error\033[0m", typedStacks.ProfileType, value, typedStacks.ErrorMargin, matchingSum, errorPct)
 				hasFailures = true
@@ -510,6 +529,14 @@ func analyzeProfDataWithFailureHandling(r Reporter, prof []StackSample, typedSta
 			}
 		} else {
 			r.Logf("\033[32mAssertion succeeded: profile '%s' has total matching sum of %1.f +/- %d%% (was %d with %.1f%% error)\033[0m", typedStacks.ProfileType, value, typedStacks.ErrorMargin, matchingSum, errorPct)
+		}
+		if opts.Sink != nil {
+			opts.Sink.RecordAssertion(AssertionEvent{
+				Scenario: opts.Scenario, Language: opts.Language,
+				ProfileType: typedStacks.ProfileType, Kind: "matching_sum",
+				ErrorPct: errorPct, ErrorMargin: typedStacks.ErrorMargin,
+				Passed: assertionPassed, AllowFailure: allowFailure,
+			})
 		}
 	}
 
@@ -663,6 +690,11 @@ func ReadPprofFile(pprofFile string) (*profile.Profile, error) {
 // stacks observed in the profile is written next to the pprof file (useful to
 // bootstrap an expected_profile.json).
 func AnalyzePprofFile(r Reporter, pprofFile string, typedStacks TypedStacks, testName string, captureData bool, scaleByDuration bool, allowFailure bool) {
+	analyzePprofFileWithSink(r, pprofFile, typedStacks, testName, captureData, scaleByDuration, allowFailure, AnalyzeOptions{})
+}
+
+// analyzePprofFileWithSink is the metrics-aware variant. opts.Sink may be nil.
+func analyzePprofFileWithSink(r Reporter, pprofFile string, typedStacks TypedStacks, testName string, captureData bool, scaleByDuration bool, allowFailure bool, opts AnalyzeOptions) {
 	prof, err := ReadPprofFile(pprofFile)
 	if err != nil {
 		r.Fatalf("Error reading file %s", pprofFile)
@@ -681,12 +713,48 @@ func AnalyzePprofFile(r Reporter, pprofFile string, typedStacks TypedStacks, tes
 		profileDuration = 0
 	}
 	typedProf := getProfileType(r, prof, typedStacks.ProfileType)
-	analyzeProfDataWithFailureHandling(r, typedProf, typedStacks, profileDuration, allowFailure)
+	analyzeProfDataWithFailureHandling(r, typedProf, typedStacks, profileDuration, allowFailure, opts)
+}
+
+// AssertionEvent is what the metrics sink receives per assertion. Defined
+// here (not in reporter/) so the analysis package has no outbound dep.
+type AssertionEvent struct {
+	Scenario     string
+	Language     string
+	ProfileType  string
+	Kind         string // "value" | "percent" | "matching_sum"
+	ErrorPct     float64
+	ErrorMargin  int64
+	Passed       bool
+	AllowFailure bool
+}
+
+// MetricsSink is the subset of `reporter.MetricsRecorder` that analysis
+// needs. Callers pass either a real recorder or nil; nil disables emission.
+type MetricsSink interface {
+	RecordAssertion(AssertionEvent)
+}
+
+// AnalyzeOptions carries optional context that the metrics sink needs in
+// order to tag each assertion with the right scenario/language.
+type AnalyzeOptions struct {
+	Sink     MetricsSink
+	Scenario string // e.g. "python_many_threads"
+	Language string // e.g. "python"
 }
 
 // AnalyzeResults loads the expected_profile.json at jsonFilePath and asserts
 // every pprof file under pprofFolder matches it. Failures are reported via r.
+//
+// This is the backwards-compatible wrapper used by external callers (e.g.
+// the GitHub Action entrypoint). It does not emit metrics.
 func AnalyzeResults(r Reporter, jsonFilePath string, pprofFolder string) {
+	AnalyzeResultsWithOpts(r, jsonFilePath, pprofFolder, AnalyzeOptions{})
+}
+
+// AnalyzeResultsWithOpts is the metrics-aware variant. When opts.Sink is nil,
+// behaviour is identical to AnalyzeResults.
+func AnalyzeResultsWithOpts(r Reporter, jsonFilePath, pprofFolder string, opts AnalyzeOptions) {
 	stackTestData, err := ReadJSONFile(jsonFilePath)
 	if err != nil {
 		r.Fatalf("Error opening file %s: %v", jsonFilePath, err)
@@ -736,7 +804,7 @@ func AnalyzeResults(r Reporter, jsonFilePath string, pprofFolder string) {
 					r.Logf("Analyzing first profile with failure tolerance enabled: %s", filepath.Base(file))
 				}
 
-				AnalyzePprofFile(r, file, typedStacks, stackTestData.TestName, !fileAlreadyProcessed, stackTestData.ScaleByDuration, allowFailure)
+				analyzePprofFileWithSink(r, file, typedStacks, stackTestData.TestName, !fileAlreadyProcessed, stackTestData.ScaleByDuration, allowFailure, opts)
 			}
 		}
 	}

--- a/analysis/api_test.go
+++ b/analysis/api_test.go
@@ -77,6 +77,54 @@ func TestPublicAPI_HappyPath(t *testing.T) {
 	}
 }
 
+// fakeSink captures every assertion the analysis pipeline emits so tests can
+// assert that the metrics sink is wired correctly.
+type fakeSink struct {
+	events []analysis.AssertionEvent
+}
+
+func (f *fakeSink) RecordAssertion(ev analysis.AssertionEvent) {
+	f.events = append(f.events, ev)
+}
+
+func TestPublicAPI_MetricsSink_EmitsPerAssertion(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalPprof(t, dir, "hot_function", 10_000_000)
+	jsonPath := writeJSON(t, dir, `{
+		"test_name": "api-sink",
+		"stacks": [{
+			"profile-type": "cpu-time",
+			"stack-content": [
+				{"regular_expression": "^hot_function$", "value": 10000000, "error_margin": 0},
+				{"regular_expression": "^nope$", "value": 1, "error_margin": 0}
+			]
+		}]
+	}`)
+
+	sink := &fakeSink{}
+	r := analysis.NewStdReporter(os.Stdout, os.Stderr)
+	analysis.Run(r, func() {
+		analysis.AnalyzeResultsWithOpts(r, jsonPath, dir, analysis.AnalyzeOptions{
+			Sink: sink, Scenario: "unit-test", Language: "python",
+		})
+	})
+	if len(sink.events) != 2 {
+		t.Fatalf("expected 2 assertion events (one per stack-content entry); got %d", len(sink.events))
+	}
+	for _, ev := range sink.events {
+		if ev.Scenario != "unit-test" || ev.Language != "python" || ev.ProfileType != "cpu-time" || ev.Kind != "value" {
+			t.Errorf("unexpected event tags: %+v", ev)
+		}
+	}
+	// First assertion passes (exact match), second fails (expected value=1 vs actual ~10M).
+	if !sink.events[0].Passed {
+		t.Errorf("expected first assertion to pass; ev=%+v", sink.events[0])
+	}
+	if sink.events[1].Passed {
+		t.Errorf("expected second assertion to fail; ev=%+v", sink.events[1])
+	}
+}
+
 // TestPublicAPI_FailingAssertion confirms Failed() is set when the profile
 // doesn't match expectations (Errorf path, no Fatalf).
 func TestPublicAPI_FailingAssertion(t *testing.T) {

--- a/correctness_test.go
+++ b/correctness_test.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/DataDog/prof-correctness/analysis"
+	"github.com/DataDog/prof-correctness/reporter"
 )
 
 func retrieveCurrentCommand(imageID string) ([]string, error) {
@@ -34,6 +37,70 @@ func runTestApp(t *testing.T, dockerTag string, folder string) string {
 	return tmpdir
 }
 
+// newReporter constructs the metrics recorder for a `testScenarios` run.
+// Returns nil and an empty cleanup when the reporter is disabled (default).
+// Activated by DD_PROF_CORRECTNESS_REPORT=1; falls back to a no-op recorder
+// (and logs a warning) if DD_API_KEY_STAGING is missing.
+func newReporter(t *testing.T) (analysis.MetricsSink, func()) {
+	if os.Getenv("DD_PROF_CORRECTNESS_REPORT") == "" {
+		return nil, func() {}
+	}
+	apiKey := os.Getenv("DD_API_KEY_STAGING")
+	if apiKey == "" {
+		t.Logf("DD_PROF_CORRECTNESS_REPORT=1 but DD_API_KEY_STAGING is empty; metrics disabled")
+		return nil, func() {}
+	}
+	site := os.Getenv("DD_SITE")
+	if site == "" {
+		site = "datad0g.com" // staging by default for this project
+	}
+	var commonTags []string
+	if v := os.Getenv("RUNNER_LABEL"); v != "" {
+		commonTags = append(commonTags, "runner_label:"+v)
+	}
+	if v := os.Getenv("GIT_REPO"); v != "" {
+		commonTags = append(commonTags, "git_repo:"+v)
+	}
+	if v := os.Getenv("GIT_BRANCH"); v != "" {
+		commonTags = append(commonTags, "git_branch:"+v)
+	}
+	rec := reporter.NewDatadogRecorder(apiKey, site, "github-actions", commonTags)
+	// Wrap with a mutex so concurrent t.Run goroutines don't race on the
+	// recorder's internal buffers (defensive — DatadogRecorder already uses
+	// its own locks, but explicit serialisation here documents intent).
+	mu := &sync.Mutex{}
+	w := &lockedRecorder{rec: rec, mu: mu}
+	cleanup := func() {
+		if err := rec.Flush(); err != nil {
+			t.Logf("reporter flush failed (non-fatal): %v", err)
+		}
+	}
+	return w, cleanup
+}
+
+// lockedRecorder adapts *reporter.DatadogRecorder to analysis.MetricsSink and
+// also serialises calls so parallel scenarios stay deterministic for tests.
+type lockedRecorder struct {
+	rec *reporter.DatadogRecorder
+	mu  *sync.Mutex
+}
+
+func (l *lockedRecorder) RecordAssertion(ev analysis.AssertionEvent) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.rec.RecordAssertion(reporter.AssertionEvent{
+		Scenario: ev.Scenario, Language: ev.Language, ProfileType: ev.ProfileType,
+		Kind: ev.Kind, ErrorPct: ev.ErrorPct, ErrorMargin: ev.ErrorMargin,
+		Passed: ev.Passed, AllowFailure: ev.AllowFailure,
+	})
+}
+
+func (l *lockedRecorder) recordScenarioResult(scenario, language string, failed bool, durationSeconds float64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.rec.RecordScenarioResult(scenario, language, failed, durationSeconds)
+}
+
 func testScenarios(t *testing.T, scenarioRegexp string) {
 	t.Logf("Considering only scenarios in %s", scenarioRegexp)
 	rootDir := "./scenarios"
@@ -47,6 +114,9 @@ func testScenarios(t *testing.T, scenarioRegexp string) {
 
 	buildBaseImages(t, configs)
 
+	sink, flushOnce := newReporter(t)
+	t.Cleanup(flushOnce)
+
 	// Run the tests
 	for _, config := range configs {
 		t.Run(config.folder, func(t *testing.T) {
@@ -56,7 +126,16 @@ func testScenarios(t *testing.T, scenarioRegexp string) {
 			tag := buildTestApp(t, config)
 			t.Log("Built test app with:", tag)
 			pprof_folder := runTestApp(t, tag, config.folder)
-			analysis.AnalyzeResults(t, config.jsonFilePath, pprof_folder)
+			scenarioName := reporter.ScenarioFromFolder(config.folder)
+			language := reporter.LanguageFromScenarioFolder(config.folder)
+			start := time.Now()
+			analysis.AnalyzeResultsWithOpts(t, config.jsonFilePath, pprof_folder, analysis.AnalyzeOptions{
+				Sink: sink, Scenario: scenarioName, Language: language,
+			})
+			durSeconds := time.Since(start).Seconds()
+			if lr, ok := sink.(*lockedRecorder); ok {
+				lr.recordScenarioResult(scenarioName, language, t.Failed(), durSeconds)
+			}
 		})
 	}
 }

--- a/reporter/datadog.go
+++ b/reporter/datadog.go
@@ -1,0 +1,338 @@
+package reporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DatadogRecorder buffers metric points in memory and submits them to the
+// Datadog HTTP API on Flush(). Designed for short-lived CI processes — one
+// flush per test process, batched in a single HTTP call per metric type.
+//
+// Distribution metrics use POST /api/v1/distribution_points.
+// Count / gauge metrics use POST /api/v1/series.
+// Both authenticate via the DD-API-KEY header.
+type DatadogRecorder struct {
+	apiKey  string
+	site    string // e.g. "datadoghq.com", "datad0g.com"
+	source  string // sent as `host` tag-equivalent on metric points
+	common  []string // tags added to every point (e.g. runner_label, git_repo)
+	client  *http.Client
+
+	// Buffered series. Distributions are accumulated per (metric, tag set)
+	// and emitted as a single list-of-values point. Counts are summed.
+	dist   safeBuffer[distPoint]
+	counts safeBuffer[countPoint]
+	gauges safeBuffer[gaugePoint]
+}
+
+// NewDatadogRecorder constructs a recorder. site defaults to "datadoghq.com"
+// if empty. commonTags are added to every metric point — typically the
+// runner_label, git_repo, git_branch. host is reported as the metric `host`;
+// "github-actions" is a sensible default for GHA jobs.
+func NewDatadogRecorder(apiKey, site, host string, commonTags []string) *DatadogRecorder {
+	if site == "" {
+		site = "datadoghq.com"
+	}
+	if host == "" {
+		host = "github-actions"
+	}
+	return &DatadogRecorder{
+		apiKey: apiKey,
+		site:   site,
+		source: host,
+		common: commonTags,
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+type distPoint struct {
+	metric string
+	tags   []string
+	ts     int64
+	values []float64
+}
+
+type countPoint struct {
+	metric string
+	tags   []string
+	ts     int64
+	value  float64
+}
+
+type gaugePoint struct {
+	metric string
+	tags   []string
+	ts     int64
+	value  float64
+}
+
+// --- MetricsRecorder impl ----------------------------------------------------
+
+// AssertionFromAnalysis bridges the analysis package's AssertionEvent struct
+// to this package's internal AssertionContext, so DatadogRecorder satisfies
+// the analysis.MetricsSink interface without analysis depending on us.
+// Each translation unit defines its own struct shape; this is the join point.
+type AssertionEvent struct {
+	Scenario, Language, ProfileType, Kind string
+	ErrorPct                              float64
+	ErrorMargin                           int64
+	Passed, AllowFailure                  bool
+}
+
+func (d *DatadogRecorder) RecordAssertion(ev AssertionEvent) {
+	ctx := AssertionContext{
+		Scenario: ev.Scenario, Language: ev.Language, ProfileType: ev.ProfileType,
+		Kind: AssertionKind(ev.Kind), ErrorPct: ev.ErrorPct,
+		ErrorMargin: ev.ErrorMargin, Passed: ev.Passed,
+		AllowFailure: ev.AllowFailure,
+	}
+	d.recordAssertion(ctx)
+}
+
+func (d *DatadogRecorder) recordAssertion(ctx AssertionContext) {
+	ts := time.Now().Unix()
+	tags := d.assertionTags(ctx)
+
+	// error_pct as distribution — preserves shape across many assertions per scenario.
+	d.dist.append(distPoint{
+		metric: "prof_correctness.assertion.error_pct",
+		tags:   tags,
+		ts:     ts,
+		values: []float64{ctx.ErrorPct},
+	})
+	// passed as count — sum yields pass count; combine with total count
+	// (datadog's `as_count()` modifier) for a pass rate.
+	var passed float64
+	if ctx.Passed {
+		passed = 1
+	}
+	d.counts.append(countPoint{
+		metric: "prof_correctness.assertion.passed",
+		tags:   tags,
+		ts:     ts,
+		value:  passed,
+	})
+	// Also a 1-per-assertion counter so we can compute pass rate.
+	d.counts.append(countPoint{
+		metric: "prof_correctness.assertion.total",
+		tags:   tags,
+		ts:     ts,
+		value:  1,
+	})
+}
+
+func (d *DatadogRecorder) RecordScenarioResult(scenario, language string, failed bool, durationSeconds float64) {
+	ts := time.Now().Unix()
+	tags := append(append([]string(nil), d.common...),
+		"scenario:"+scenario,
+		"language:"+language,
+	)
+	var f float64
+	if failed {
+		f = 1
+	}
+	d.counts.append(countPoint{
+		metric: "prof_correctness.scenario.failed",
+		tags:   tags,
+		ts:     ts,
+		value:  f,
+	})
+	d.counts.append(countPoint{
+		metric: "prof_correctness.scenario.total",
+		tags:   tags,
+		ts:     ts,
+		value:  1,
+	})
+	d.gauges.append(gaugePoint{
+		metric: "prof_correctness.scenario.duration_seconds",
+		tags:   tags,
+		ts:     ts,
+		value:  durationSeconds,
+	})
+}
+
+func (d *DatadogRecorder) assertionTags(ctx AssertionContext) []string {
+	out := make([]string, 0, len(d.common)+6)
+	out = append(out, d.common...)
+	out = append(out,
+		"scenario:"+ctx.Scenario,
+		"language:"+ctx.Language,
+		"profile_type:"+ctx.ProfileType,
+		"assertion_kind:"+string(ctx.Kind),
+	)
+	if ctx.AllowFailure {
+		out = append(out, "allow_failure:true")
+	}
+	return out
+}
+
+// --- Submission --------------------------------------------------------------
+
+func (d *DatadogRecorder) Flush() error {
+	if err := d.flushDist(); err != nil {
+		return fmt.Errorf("distribution_points: %w", err)
+	}
+	if err := d.flushSeries(); err != nil {
+		return fmt.Errorf("series: %w", err)
+	}
+	return nil
+}
+
+func (d *DatadogRecorder) flushDist() error {
+	pts := d.dist.drain()
+	if len(pts) == 0 {
+		return nil
+	}
+	type apiDistPoint struct {
+		Metric string      `json:"metric"`
+		Host   string      `json:"host,omitempty"`
+		Tags   []string    `json:"tags,omitempty"`
+		// Distributions submit points as [[timestamp, [values...]]].
+		Points [][2]any `json:"points"`
+	}
+	payload := struct {
+		Series []apiDistPoint `json:"series"`
+	}{}
+	// Group by (metric, sorted-tags) so we send one point per group.
+	type key struct {
+		metric string
+		tags   string
+	}
+	grouped := map[key]*apiDistPoint{}
+	for _, p := range pts {
+		k := key{p.metric, joinSortedTags(p.tags)}
+		ap, ok := grouped[k]
+		if !ok {
+			ap = &apiDistPoint{
+				Metric: p.metric,
+				Host:   d.source,
+				Tags:   sortedTagsCopy(p.tags),
+				Points: [][2]any{{p.ts, []float64{}}},
+			}
+			grouped[k] = ap
+		}
+		// First (and only) point's value-array is the second element.
+		vals := ap.Points[0][1].([]float64)
+		vals = append(vals, p.values...)
+		ap.Points[0][1] = vals
+	}
+	for _, ap := range grouped {
+		payload.Series = append(payload.Series, *ap)
+	}
+	return d.postJSON("/api/v1/distribution_points", payload)
+}
+
+func (d *DatadogRecorder) flushSeries() error {
+	counts := d.counts.drain()
+	gauges := d.gauges.drain()
+	if len(counts) == 0 && len(gauges) == 0 {
+		return nil
+	}
+	type apiSeriesPoint struct {
+		Metric   string      `json:"metric"`
+		Host     string      `json:"host,omitempty"`
+		Tags     []string    `json:"tags,omitempty"`
+		Type     string      `json:"type"`
+		Interval *int64      `json:"interval,omitempty"`
+		Points   [][2]float64 `json:"points"`
+	}
+	payload := struct {
+		Series []apiSeriesPoint `json:"series"`
+	}{}
+
+	// Counts: sum values by (metric, tags) so the API receives one point per
+	// group. Interval=1 marks them as 1-second buckets; the agent normalises.
+	type key struct{ m, t string }
+	cgrouped := map[key]*apiSeriesPoint{}
+	intervalOne := int64(1)
+	for _, c := range counts {
+		k := key{c.metric, joinSortedTags(c.tags)}
+		ap, ok := cgrouped[k]
+		if !ok {
+			ap = &apiSeriesPoint{
+				Metric:   c.metric,
+				Host:     d.source,
+				Tags:     sortedTagsCopy(c.tags),
+				Type:     "count",
+				Interval: &intervalOne,
+				Points:   [][2]float64{{float64(c.ts), 0}},
+			}
+			cgrouped[k] = ap
+		}
+		ap.Points[0][1] += c.value
+	}
+	for _, ap := range cgrouped {
+		payload.Series = append(payload.Series, *ap)
+	}
+
+	// Gauges: last value wins per (metric, tags) — there's typically only one anyway.
+	ggrouped := map[key]*apiSeriesPoint{}
+	for _, g := range gauges {
+		k := key{g.metric, joinSortedTags(g.tags)}
+		ggrouped[k] = &apiSeriesPoint{
+			Metric: g.metric,
+			Host:   d.source,
+			Tags:   sortedTagsCopy(g.tags),
+			Type:   "gauge",
+			Points: [][2]float64{{float64(g.ts), g.value}},
+		}
+	}
+	for _, ap := range ggrouped {
+		payload.Series = append(payload.Series, *ap)
+	}
+
+	return d.postJSON("/api/v1/series", payload)
+}
+
+func (d *DatadogRecorder) postJSON(path string, body any) error {
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return fmt.Errorf("encode: %w", err)
+	}
+	url := "https://api." + d.site + path
+	req, err := http.NewRequest(http.MethodPost, url, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("DD-API-KEY", d.apiKey)
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Datadog returns 202 Accepted on success. Anything else is a problem.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("POST %s: HTTP %d: %s", path, resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// joinSortedTags returns a key suitable for map de-duplication: the tags
+// joined by '\x00' after a stable sort. We don't reuse strings.Join because
+// we want the side-effect-free version of the tag list to come out of
+// sortedTagsCopy.
+func joinSortedTags(tags []string) string {
+	cp := sortedTagsCopy(tags)
+	return strings.Join(cp, "\x00")
+}
+
+func sortedTagsCopy(tags []string) []string {
+	cp := append([]string(nil), tags...)
+	// Insertion sort — tag lists are short (<10).
+	for i := 1; i < len(cp); i++ {
+		for j := i; j > 0 && cp[j-1] > cp[j]; j-- {
+			cp[j-1], cp[j] = cp[j], cp[j-1]
+		}
+	}
+	return cp
+}

--- a/reporter/datadog_test.go
+++ b/reporter/datadog_test.go
@@ -1,0 +1,210 @@
+package reporter
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeBackend captures the JSON payloads sent to /api/v1/series and
+// /api/v1/distribution_points so tests can assert on metric shape.
+type fakeBackend struct {
+	mu    sync.Mutex
+	calls map[string][]map[string]any // path -> list of decoded payloads
+}
+
+func newFakeBackend(t *testing.T) (*httptest.Server, *fakeBackend) {
+	t.Helper()
+	fb := &fakeBackend{calls: map[string][]map[string]any{}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("DD-API-KEY") != "test-key" {
+			t.Errorf("missing/incorrect DD-API-KEY header: %q", r.Header.Get("DD-API-KEY"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("wrong content type: %q", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		var decoded map[string]any
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Errorf("invalid JSON body on %s: %v", r.URL.Path, err)
+		}
+		fb.mu.Lock()
+		fb.calls[r.URL.Path] = append(fb.calls[r.URL.Path], decoded)
+		fb.mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, fb
+}
+
+// rewriteToTestServer replaces the recorder's site so requests go to the
+// test server. This pokes at unexported state on purpose — keeps the public
+// constructor honest about its URL pattern.
+func rewriteToTestServer(r *DatadogRecorder, srv *httptest.Server) {
+	// Strip "https://api." prefix from the test server's URL so the
+	// existing "https://api.<site>" template produces srv.URL.
+	host := strings.TrimPrefix(srv.URL, "http://")
+	r.site = host
+	// Override the client to use http (not https) — easier than wiring TLS.
+	tr := &http.Transport{Proxy: nil}
+	r.client.Transport = &rewriteTransport{base: tr, target: srv.URL}
+}
+
+type rewriteTransport struct {
+	base   http.RoundTripper
+	target string
+}
+
+func (t *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace scheme + host with the httptest server.
+	newURL := t.target + req.URL.Path
+	if req.URL.RawQuery != "" {
+		newURL += "?" + req.URL.RawQuery
+	}
+	r2 := req.Clone(req.Context())
+	u, err := req.URL.Parse(newURL)
+	if err != nil {
+		return nil, err
+	}
+	r2.URL = u
+	r2.Host = u.Host
+	return t.base.RoundTrip(r2)
+}
+
+func TestDatadogRecorder_FlushEmits(t *testing.T) {
+	srv, fb := newFakeBackend(t)
+
+	rec := NewDatadogRecorder("test-key", "datadoghq.com", "ci-host",
+		[]string{"git_repo:DataDog/prof-correctness", "runner_label:ubuntu-8-core-latest"})
+	rewriteToTestServer(rec, srv)
+
+	// Two assertions, same scenario but different profile_type — should
+	// produce one distribution point per unique tag set.
+	rec.RecordAssertion(AssertionEvent{
+		Scenario: "python_many_threads", Language: "python",
+		ProfileType: "wall-time", Kind: "value",
+		ErrorPct: 2.3, ErrorMargin: 15, Passed: true,
+	})
+	rec.RecordAssertion(AssertionEvent{
+		Scenario: "python_many_threads", Language: "python",
+		ProfileType: "wall-time", Kind: "value",
+		ErrorPct: 7.1, ErrorMargin: 15, Passed: true,
+	})
+	rec.RecordAssertion(AssertionEvent{
+		Scenario: "python_many_threads", Language: "python",
+		ProfileType: "cpu-time", Kind: "value",
+		ErrorPct: 12.5, ErrorMargin: 15, Passed: false,
+	})
+	rec.RecordScenarioResult("python_many_threads", "python", false, 32.4)
+
+	if err := rec.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+
+	// One call to /api/v1/distribution_points and one to /api/v1/series.
+	if len(fb.calls["/api/v1/distribution_points"]) != 1 {
+		t.Fatalf("expected 1 distribution_points call, got %d: %+v",
+			len(fb.calls["/api/v1/distribution_points"]), fb.calls)
+	}
+	if len(fb.calls["/api/v1/series"]) != 1 {
+		t.Fatalf("expected 1 series call, got %d", len(fb.calls["/api/v1/series"]))
+	}
+
+	// Distribution should have 2 groups (wall-time + cpu-time), each with the right values.
+	distPayload := fb.calls["/api/v1/distribution_points"][0]
+	series, ok := distPayload["series"].([]any)
+	if !ok || len(series) != 2 {
+		t.Fatalf("distribution series shape unexpected: %T %v", distPayload["series"], distPayload)
+	}
+	totalValues := 0
+	for _, s := range series {
+		obj := s.(map[string]any)
+		if obj["metric"] != "prof_correctness.assertion.error_pct" {
+			t.Errorf("unexpected metric: %v", obj["metric"])
+		}
+		pts := obj["points"].([]any)
+		if len(pts) != 1 {
+			t.Errorf("expected 1 point per group, got %d", len(pts))
+		}
+		vals := pts[0].([]any)[1].([]any)
+		totalValues += len(vals)
+	}
+	if totalValues != 3 {
+		t.Errorf("expected 3 distribution values total (2 wall-time + 1 cpu-time), got %d", totalValues)
+	}
+
+	// Series should contain assertion.passed, assertion.total, scenario.failed,
+	// scenario.total, scenario.duration_seconds.
+	seriesPayload := fb.calls["/api/v1/series"][0]
+	metrics := map[string]bool{}
+	for _, s := range seriesPayload["series"].([]any) {
+		metrics[s.(map[string]any)["metric"].(string)] = true
+	}
+	for _, want := range []string{
+		"prof_correctness.assertion.passed",
+		"prof_correctness.assertion.total",
+		"prof_correctness.scenario.failed",
+		"prof_correctness.scenario.total",
+		"prof_correctness.scenario.duration_seconds",
+	} {
+		if !metrics[want] {
+			t.Errorf("missing metric %q in series payload; got %v", want, metrics)
+		}
+	}
+}
+
+func TestDatadogRecorder_NoFlushOnEmpty(t *testing.T) {
+	srv, fb := newFakeBackend(t)
+	rec := NewDatadogRecorder("test-key", "datadoghq.com", "host", nil)
+	rewriteToTestServer(rec, srv)
+	if err := rec.Flush(); err != nil {
+		t.Fatalf("Flush with no data: %v", err)
+	}
+	if len(fb.calls) != 0 {
+		t.Errorf("expected no HTTP calls on empty Flush, got %d", len(fb.calls))
+	}
+}
+
+func TestLanguageFromScenarioFolder(t *testing.T) {
+	cases := map[string]string{
+		"scenarios/python_many_threads":   "python",
+		"./scenarios/ruby_heap_4x":        "ruby",
+		"scenarios/ddprof":                "ddprof",
+		"python_gil_contention_3.11":      "python",
+		"":                                "unknown",
+	}
+	for in, want := range cases {
+		if got := LanguageFromScenarioFolder(in); got != want {
+			t.Errorf("LanguageFromScenarioFolder(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestScenarioFromFolder(t *testing.T) {
+	cases := map[string]string{
+		"scenarios/python_many_threads":   "python_many_threads",
+		"./scenarios/ruby_heap_4x":        "ruby_heap_4x",
+		"python_gil_contention_3.11":      "python_gil_contention_3.11",
+	}
+	for in, want := range cases {
+		if got := ScenarioFromFolder(in); got != want {
+			t.Errorf("ScenarioFromFolder(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNoopRecorder(t *testing.T) {
+	var r MetricsRecorder = NoopRecorder{}
+	r.RecordAssertion(AssertionEvent{}) // does not panic
+	r.RecordScenarioResult("s", "lang", true, 1.0)
+	if err := r.Flush(); err != nil {
+		t.Errorf("NoopRecorder.Flush returned non-nil: %v", err)
+	}
+}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -1,0 +1,112 @@
+// Package reporter ships per-assertion and per-scenario metrics from
+// prof-correctness runs to a Datadog backend. Default is no-op; the Datadog
+// implementation is activated via DD_PROF_CORRECTNESS_REPORT=1 plus the
+// usual DD_API_KEY_STAGING / DD_SITE env vars.
+//
+// Tag set is deliberately low-cardinality (scenario, language, profile_type,
+// assertion_kind, runner_label) so we stay well under Datadog's custom-metric
+// budget. High-cardinality context (git_sha, ci_run_id, individual stack
+// regexes) is intentionally not on metric tags — it belongs on CI Visibility
+// or in failure logs.
+package reporter
+
+import (
+	"strings"
+	"sync"
+)
+
+// AssertionKind is the kind of assertion that was evaluated. Constants are
+// chosen to match what `analysis/analysis.go` already distinguishes
+// (per-stack value, per-stack percent, per-typed-stacks matching sum).
+type AssertionKind string
+
+const (
+	AssertionKindValue        AssertionKind = "value"
+	AssertionKindPercent      AssertionKind = "percent"
+	AssertionKindMatchingSum  AssertionKind = "matching_sum"
+)
+
+// AssertionContext is what the recorder needs to know per assertion. All
+// fields are required (no zero-value sentinels).
+type AssertionContext struct {
+	Scenario     string        // e.g. "python_many_threads"
+	Language     string        // first folder segment, e.g. "python", "ddprof", "ruby"
+	ProfileType  string        // e.g. "wall-time", "cpu-time", "alloc-space"
+	Kind         AssertionKind
+	ErrorPct     float64 // unsigned: percent deviation from expected value
+	ErrorMargin  int64   // configured threshold (percent)
+	Passed       bool
+	AllowFailure bool // true when the assertion is in the "first profile" tolerance window
+}
+
+// MetricsRecorder collects per-assertion and per-scenario events.
+// All methods must be safe to call from multiple goroutines (Go tests can
+// run scenarios in parallel via t.Parallel()).
+type MetricsRecorder interface {
+	RecordAssertion(ev AssertionEvent)
+	RecordScenarioResult(scenario, language string, failed bool, durationSeconds float64)
+	// Flush sends any buffered metrics to the backend and returns any
+	// transport error. Implementations must never panic; callers may ignore
+	// the error if they choose to (correctness tests should not fail because
+	// reporting failed).
+	Flush() error
+}
+
+// NoopRecorder discards everything. Used when reporting is disabled.
+type NoopRecorder struct{}
+
+func (NoopRecorder) RecordAssertion(AssertionEvent)                            {}
+func (NoopRecorder) RecordScenarioResult(string, string, bool, float64)        {}
+func (NoopRecorder) Flush() error                                              { return nil }
+
+// LanguageFromScenarioFolder extracts the language tag from a scenario folder
+// path like "scenarios/python_many_threads" → "python". Convention is that
+// each scenario folder is named "<lang>_<topic>"; the first underscore-
+// separated segment is the language. Unknown/unparseable folders return
+// "unknown" rather than failing — we never want the recorder to break a test.
+func LanguageFromScenarioFolder(folder string) string {
+	// Strip a "scenarios/" prefix if present so callers can pass either.
+	folder = strings.TrimPrefix(folder, "scenarios/")
+	folder = strings.TrimPrefix(folder, "./scenarios/")
+	if folder == "" {
+		return "unknown"
+	}
+	if idx := strings.IndexByte(folder, '_'); idx > 0 {
+		return folder[:idx]
+	}
+	// No underscore — treat whole folder as language (e.g. "ddprof").
+	return folder
+}
+
+// ScenarioFromFolder strips the "scenarios/" prefix so the tag is just the
+// scenario name (e.g. "python_many_threads"), matching what a human would
+// write in a Datadog query.
+func ScenarioFromFolder(folder string) string {
+	folder = strings.TrimPrefix(folder, "scenarios/")
+	folder = strings.TrimPrefix(folder, "./scenarios/")
+	return folder
+}
+
+// --- Thread-safety helper ----------------------------------------------------
+
+// safeBuffer is a small concurrent-safe slice wrapper used by the Datadog
+// recorder to accumulate points between Flush() calls. Kept here so concrete
+// implementations can reuse it.
+type safeBuffer[T any] struct {
+	mu   sync.Mutex
+	data []T
+}
+
+func (b *safeBuffer[T]) append(v T) {
+	b.mu.Lock()
+	b.data = append(b.data, v)
+	b.mu.Unlock()
+}
+
+func (b *safeBuffer[T]) drain() []T {
+	b.mu.Lock()
+	out := b.data
+	b.data = nil
+	b.mu.Unlock()
+	return out
+}


### PR DESCRIPTION
## What

Adds a new \`reporter/\` package and wires it into the analysis pipeline so each scenario run can emit metrics to Datadog staging (\`datad0g.com\`):

| metric | type | purpose |
|---|---|---|
| \`prof_correctness.assertion.error_pct\` | distribution | per-assertion error %; P50/P95 dashboards |
| \`prof_correctness.assertion.passed\` / \`.total\` | count | per-tag pass rate |
| \`prof_correctness.scenario.failed\` / \`.total\` | count | per-scenario pass rate |
| \`prof_correctness.scenario.duration_seconds\` | gauge | catch slowdowns |

Tags (low-cardinality on purpose): \`scenario\`, \`language\`, \`profile_type\`, \`assertion_kind\`, \`runner_label\`, \`git_repo\`, \`git_branch\`. No \`git_sha\` / no \`stack_regex\` / no \`ci_run_id\` — that context lives in CI Visibility. Putting it on metric tags would blow up the custom-metric budget.

## How

- New package \`reporter/\` with \`DatadogRecorder\` (HTTP submission to \`api.datad0g.com/api/v1/{series,distribution_points}\`) and \`NoopRecorder\`. Unit-tested against an \`httptest\` server.
- New \`analysis.AnalyzeResultsWithOpts\` plumbs an optional \`MetricsSink\` + \`scenario\`/\`language\` tags through the assertion path. Existing \`analysis.AnalyzeResults\` is preserved as a backwards-compatible wrapper (the GitHub Action in \`analyze/\` keeps working unchanged).
- \`correctness_test.go\` builds the recorder from env in \`testScenarios\`, flushes once via \`t.Cleanup\`.
- \`.github/workflows/test.yml\` enables reporting only on \`push@main\` and the nightly schedule. PR runs stay silent.

## Activation

The recorder is **default-off**. It only emits when \`DD_PROF_CORRECTNESS_REPORT=1\` AND \`DD_API_KEY_STAGING\` is set. Local \`go test\` runs and PR CI runs send nothing.

## Pre-requisite

\`DD_API_KEY_STAGING\` repo secret must be provisioned (in progress at PR open time).

## Tests

\`\`\`
ok  github.com/DataDog/prof-correctness/analysis      0.5s
ok  github.com/DataDog/prof-correctness/reporter      0.7s
ok  github.com/DataDog/prof-correctness/cmd/...       1.2s
\`\`\`

New test \`TestPublicAPI_MetricsSink_EmitsPerAssertion\` confirms the sink is called once per assertion with the right scenario/language/profile_type/kind/passed values. New \`reporter\` tests cover HTTP submission shape, tag grouping, and the no-op path.