### PR TITLE
[ci] send readable scenario names to Slack on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,4 +81,4 @@ jobs:
       run: |
         curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
              -H 'Content-Type: application/json' \
-             -d "{'scenarios': '${{ matrix.regex }}', 'failed_run_url': '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'}"
+             -d "{'scenarios': '${{ matrix.names }}', 'failed_run_url': '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'}"

--- a/cmd/list-scenarios/main.go
+++ b/cmd/list-scenarios/main.go
@@ -27,8 +27,16 @@ import (
 )
 
 type matrixEntry struct {
+	// Shard is a short human-readable label like "3/9". Used for the job name.
 	Shard string `json:"shard"`
+	// Regex is the path-anchored regex consumed by the Go test runner via
+	// TEST_SCENARIOS. It matches against filepath.Dir(dockerfile), e.g.
+	// "scenarios/python_cpu", so a bare name would substring-match.
 	Regex string `json:"regex"`
+	// Names is the comma-separated list of scenario directory names in this
+	// chunk. Used for human-facing surfaces (Slack notifications, artifact
+	// names) where the regex blob is unreadable.
+	Names string `json:"names"`
 }
 
 func run(pattern, scenariosDir string, chunkSize int) ([]matrixEntry, error) {
@@ -72,6 +80,7 @@ func run(pattern, scenariosDir string, chunkSize int) ([]matrixEntry, error) {
 		out[i] = matrixEntry{
 			Shard: fmt.Sprintf("%d/%d", i+1, len(chunks)),
 			Regex: "(^|/)(" + strings.Join(c, "|") + ")$",
+			Names: strings.Join(c, ", "),
 		}
 	}
 	return out, nil

--- a/cmd/list-scenarios/main_test.go
+++ b/cmd/list-scenarios/main_test.go
@@ -46,10 +46,12 @@ func TestRun_ChunksAlphabetically(t *testing.T) {
 		{
 			Shard: "1/2",
 			Regex: "(^|/)(python_asyncio_3.11|python_basic_3.10|python_basic_3.11)$",
+			Names: "python_asyncio_3.11, python_basic_3.10, python_basic_3.11",
 		},
 		{
 			Shard: "2/2",
 			Regex: "(^|/)(python_cpu|python_deep_stack_3.11)$",
+			Names: "python_cpu, python_deep_stack_3.11",
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -72,6 +74,9 @@ func TestRun_SingleChunkWhenSmall(t *testing.T) {
 	}
 	if got[0].Regex != "(^|/)(dotnet_alloc|dotnet_wall)$" {
 		t.Errorf("regex: got %q", got[0].Regex)
+	}
+	if got[0].Names != "dotnet_alloc, dotnet_wall" {
+		t.Errorf("names: got %q", got[0].Names)
 	}
 }
 


### PR DESCRIPTION
## Why

Slack notifications for failed scenario jobs were sending the raw matrix regex blob:

`(^|/)(python_many_threads|python_multiprocessing|python_native_cpu_3.11)$`

That regex is what the Go test runner needs — `findDockerConfigs` matches the user pattern against `filepath.Dir(dockerfile)` (e.g. `scenarios/python_cpu`), so we anchor with `(^|/)…$` to avoid substring matches like `python_cpu` ⊂ `python_cpu_sleep_sync_3.12`. Correct, but unreadable in a Slack message.

## What

Add a third `names` field on each matrix entry emitted by `cmd/list-scenarios` — a comma-separated list of the scenario dirs in that chunk — and use `matrix.names` instead of `matrix.regex` in the Slack payload.

`TEST_SCENARIOS` continues to use `matrix.regex` unchanged.

Example Slack payload going from:
`{'scenarios': '(^|/)(python_many_threads|python_multiprocessing|python_native_cpu_3.11)$', ...}`
to:
`{'scenarios': 'python_many_threads, python_multiprocessing, python_native_cpu_3.11', ...}`

Tests in `cmd/list-scenarios/main_test.go` updated accordingly.