### PR TITLE
[python_many_threads] Bump error margin

### DIFF
--- a/scenarios/python_many_threads/expected_profile.json
+++ b/scenarios/python_many_threads/expected_profile.json
@@ -7,7 +7,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -23,7 +23,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -39,7 +39,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -55,7 +55,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -71,7 +71,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -87,7 +87,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -103,7 +103,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -119,7 +119,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -135,7 +135,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -151,7 +151,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -167,7 +167,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -183,7 +183,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -199,7 +199,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -215,7 +215,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -231,7 +231,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -247,7 +247,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -263,7 +263,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -279,7 +279,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -295,7 +295,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",
@@ -311,7 +311,7 @@
         {
           "regular_expression": ".*worker",
           "value": 1000000000,
-          "error_margin": 5,
+          "error_margin": 7,
           "labels": [
             {
               "key": "thread name",


### PR DESCRIPTION
## What is this PR?

This PR bumps the error margin for the `many_threads` scenario. I don't especially like that I have to do that, but it's flaky and it's the only way I see to deflake it without having to de-down-sample too much.

I did 30 runs locally and it never got about 6.2%, so I figured 7% would be a good fit.