### PR TITLE
[NO-TICKET] Reduce Ruby heap test scenario variation

### DIFF
--- a/scenarios/ruby_heap/main.rb
+++ b/scenarios/ruby_heap/main.rb
@@ -143,6 +143,12 @@ puts "Reshuffles enabled?: #{disable_reshuffle ? 'no' : 'yes'}"
 reshuffle_secs = 0.5
 gc_every_secs = 1
 sleep_budget = 0
+
+# Let Ruby clean all garbage and the dynamic sampling rate settle down before we start the benchmark to reduce
+# variance during the assertions
+GC.start
+sleep 1
+
 while (start = Process.clock_gettime(Process::CLOCK_MONOTONIC)) < end_time
   # Shift allocationg ordering a bit. In a real app there would naturally be some
   # variance to requests/tasks but here each loop looks much the same as the one before.


### PR DESCRIPTION
**What does this PR do?**

This PR adds an additional GC trigger and sleep at the beginning of the Ruby heap test scenarios so that the GC and dynamic sampling rate start with a clean slate.

**Motivation:**

We've seen these tests flake due to run-to-run variation. Rather than loosening the error ranges in the `expected_profile.json` files, I experimented locally with this "try to create a clean slate" approach and I was getting more accurate results without needing to loosen errors.

In particular the "ruby_heap" and "ruby_heap_r4" tests don't do a lot of allocations (e.g. when compared to "ruby_heap_highload" and "ruby_heap_highload_r4") and thus cause a lot more run-to-run variation.

(Which kinda makes sense? The less allocations, the less the dynamic sampling rate has to work with, and with small numbers we get more noise in the reads)

**Additional Notes:**

N/A

**How to test the change?**

Green CI is the target! If not, we'll keep at it :)