### PR TITLE
Add java_cpu_alloc scenario for the Datadog java-profiler

### DIFF
--- a/scenarios/java_cpu_alloc/CpuAllocWorkload.java
+++ b/scenarios/java_cpu_alloc/CpuAllocWorkload.java
@@ -1,3 +1,5 @@
+import java.util.concurrent.locks.LockSupport;
+
 /**
  * Deterministic two-thread workload for the java_cpu_alloc prof-correctness scenario.
  *
@@ -6,7 +8,7 @@
  * subclasses (not lambdas/anonymous classes) keep frame names stable across
  * JDK versions for the expected_profile.json regexes.
  */
-public class Workload {
+public class CpuAllocWorkload {
 
     static volatile boolean running = true;
     static volatile long sink = 0;
@@ -49,7 +51,7 @@ public class Workload {
                 for (int i = 0; i < BATCH_SIZE; i++) {
                     sink += allocate().length;
                 }
-                java.util.concurrent.locks.LockSupport.parkNanos(PARK_NANOS);
+                LockSupport.parkNanos(PARK_NANOS);
             }
         }
 

--- a/scenarios/java_cpu_alloc/Dockerfile
+++ b/scenarios/java_cpu_alloc/Dockerfile
@@ -1,0 +1,77 @@
+# Multi-stage scenario for the Datadog java-profiler.
+#
+# Stage 1 builds jfr2pprof (btraceio/jafar, PROF-15286) from source, pinned to a
+# known-good commit, since it is not yet published as a Maven Central artifact
+# or a GitHub release asset.
+# Stage 2 downloads the java-profiler native agent from a GitHub release,
+# compiles the workload, runs it under the agent to record a .jfr, then
+# converts that recording to pprof via jfr2pprof + datadog.yaml (PROF-15289).
+FROM eclipse-temurin:25-jdk AS jfr2pprof-build
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# jfr2pprof's `parser` module dependency declares a Java 8 toolchain and
+# jfr2pprof itself declares Java 21; jafar's settings.gradle doesn't wire up
+# the foojay-resolver plugin, so Gradle can't auto-provision either -
+# install both explicitly and point Gradle at them below.
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) JDK_ARCH=x64 ;; \
+         arm64) JDK_ARCH=aarch64 ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && mkdir -p /opt/jdk8 /opt/jdk21 \
+    && curl -fsSL "https://api.adoptium.net/v3/binary/latest/8/ga/linux/${JDK_ARCH}/jdk/hotspot/normal/eclipse" \
+       | tar xz -C /opt/jdk8 --strip-components=1 \
+    && curl -fsSL "https://api.adoptium.net/v3/binary/latest/21/ga/linux/${JDK_ARCH}/jdk/hotspot/normal/eclipse" \
+       | tar xz -C /opt/jdk21 --strip-components=1
+
+WORKDIR /build
+# Pinned to the jafar release that fixes https://github.com/btraceio/jafar/issues/105
+# (frame.format was parsed but never applied to pprof Function.Name).
+ARG JAFAR_COMMIT=8dde4267210952b2e3347c72efd4cd54833e903d
+RUN git init . \
+    && git remote add origin https://github.com/btraceio/jafar.git \
+    && git fetch --depth 1 origin ${JAFAR_COMMIT} \
+    && git checkout FETCH_HEAD
+
+RUN ./gradlew --no-daemon \
+      -Porg.gradle.java.installations.paths=/opt/jdk8,/opt/jdk21 \
+      -Porg.gradle.java.installations.auto-detect=false \
+      -Porg.gradle.java.installations.auto-download=false \
+      :jfr2pprof:shadowJar \
+    && cp jfr2pprof/build/libs/jfr2pprof-*-all.jar /build/jfr2pprof.jar
+
+FROM eclipse-temurin:25-jdk AS workload-build
+
+COPY ./scenarios/java_cpu_alloc/Workload.java /build/Workload.java
+RUN mkdir -p /build/classes && javac -d /build/classes /build/Workload.java
+
+FROM eclipse-temurin:25-jre AS runtime
+
+WORKDIR /app
+
+# Datadog java-profiler native agent (must match a released libjavaProfiler.so).
+ARG JAVA_PROFILER_VERSION=1.45.0
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) SO_ARCH=x64 ;; \
+         arm64) SO_ARCH=arm64 ;; \
+         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL -o /app/libjavaProfiler.so \
+       "https://github.com/DataDog/java-profiler/releases/download/v_${JAVA_PROFILER_VERSION}/libjavaProfiler_linux-${SO_ARCH}.so"
+
+COPY --from=jfr2pprof-build /build/jfr2pprof.jar /app/jfr2pprof.jar
+COPY --from=workload-build /build/classes /app
+COPY ./scenarios/java_cpu_alloc/datadog.yaml /app/datadog.yaml
+COPY ./scenarios/java_cpu_alloc/run.sh /app/run.sh
+
+RUN chmod 755 /app/run.sh
+
+ENV EXECUTION_TIME_SEC="10"
+
+CMD ["/app/run.sh"]

--- a/scenarios/java_cpu_alloc/Dockerfile
+++ b/scenarios/java_cpu_alloc/Dockerfile
@@ -1,54 +1,16 @@
 # Multi-stage scenario for the Datadog java-profiler.
 #
-# Stage 1 builds jfr2pprof (btraceio/jafar) from source, pinned to a
-# known-good commit, since it is not yet published as a Maven Central artifact
-# or a GitHub release asset.
+# Stage 1 compiles the workload.
 # Stage 2 downloads the java-profiler native agent from a GitHub release,
-# compiles the workload, runs it under the agent to record a .jfr, then
-# converts that recording to pprof via jfr2pprof + datadog.yaml.
-FROM eclipse-temurin:25-jdk AS jfr2pprof-build
-
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# jfr2pprof's `parser` module dependency declares a Java 8 toolchain and
-# jfr2pprof itself declares Java 21; jafar's settings.gradle doesn't wire up
-# the foojay-resolver plugin, so Gradle can't auto-provision either -
-# install both explicitly and point Gradle at them below.
-RUN ARCH="$(dpkg --print-architecture)" \
-    && case "$ARCH" in \
-         amd64) JDK_ARCH=x64 ;; \
-         arm64) JDK_ARCH=aarch64 ;; \
-         *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
-       esac \
-    && mkdir -p /opt/jdk8 /opt/jdk21 \
-    && curl -fsSL "https://api.adoptium.net/v3/binary/latest/8/ga/linux/${JDK_ARCH}/jdk/hotspot/normal/eclipse" \
-       | tar xz -C /opt/jdk8 --strip-components=1 \
-    && curl -fsSL "https://api.adoptium.net/v3/binary/latest/21/ga/linux/${JDK_ARCH}/jdk/hotspot/normal/eclipse" \
-       | tar xz -C /opt/jdk21 --strip-components=1
-
-WORKDIR /build
-# Pinned to the jafar release that fixes https://github.com/btraceio/jafar/issues/105
-# (frame.format was parsed but never applied to pprof Function.Name).
-ARG JAFAR_COMMIT=8dde4267210952b2e3347c72efd4cd54833e903d
-RUN git init . \
-    && git remote add origin https://github.com/btraceio/jafar.git \
-    && git fetch --depth 1 origin ${JAFAR_COMMIT} \
-    && git checkout FETCH_HEAD
-
-RUN ./gradlew --no-daemon \
-      -Porg.gradle.java.installations.paths=/opt/jdk8,/opt/jdk21 \
-      -Porg.gradle.java.installations.auto-detect=false \
-      -Porg.gradle.java.installations.auto-download=false \
-      :jfr2pprof:shadowJar \
-    && cp jfr2pprof/build/libs/jfr2pprof-*-all.jar /build/jfr2pprof.jar
-
+# runs the workload under the agent to record a .jfr, then converts that
+# recording to pprof via jfr2pprof (btraceio/jafar, launched through jbang's
+# jafar-tools-latest@btraceio alias) + datadog.yaml.
 FROM eclipse-temurin:25-jdk AS workload-build
 
 COPY ./scenarios/java_cpu_alloc/CpuAllocWorkload.java /build/CpuAllocWorkload.java
 RUN mkdir -p /build/classes && javac -d /build/classes /build/CpuAllocWorkload.java
 
-FROM eclipse-temurin:25-jre AS runtime
+FROM eclipse-temurin:25-jdk AS runtime
 
 WORKDIR /app
 
@@ -71,7 +33,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
     && curl -fsSL -o /app/libjavaProfiler.so \
        "https://github.com/DataDog/java-profiler/releases/download/${TAG}/libjavaProfiler_linux-${SO_ARCH}.so"
 
-COPY --from=jfr2pprof-build /build/jfr2pprof.jar /app/jfr2pprof.jar
+# jfr2pprof, via jbang's jafar-tools-latest@btraceio alias (btraceio/jbang-catalog).
+# Resolved at build time so run.sh doesn't need network access; jbang re-checks
+# for a newer snapshot on every `jbang app install`/first run of a given
+# coordinate but is otherwise offline once cached under JBANG_DIR.
+# JBANG_DIR is pinned to a fixed, world-writable path (rather than the
+# default ~/.jbang) because the container is run as an arbitrary non-root
+# uid:gid (see prof-correctness's -u flag), which has no /etc/passwd entry
+# and thus no writable $HOME. HOME is likewise repointed here since jbang's
+# Maven resolver falls back to $HOME/.m2 regardless of JBANG_DIR.
+ENV JBANG_DIR="/opt/jbang"
+ENV HOME="${JBANG_DIR}"
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -Ls https://sh.jbang.dev | bash -s - app setup \
+    && chmod -R a+rwX "${JBANG_DIR}"
+ENV PATH="${JBANG_DIR}/bin:${PATH}"
+# jfr2pprof has no --help; running it bare still resolves/caches the jbang
+# dependency, it just exits non-zero after printing its usage string.
+RUN jbang trust add https://github.com/btraceio/ \
+    && (jbang jafar-tools-latest@btraceio jfr2pprof || true) \
+    && chmod -R a+rwX "${JBANG_DIR}"
+
 COPY --from=workload-build /build/classes /app
 COPY ./scenarios/java_cpu_alloc/datadog.yaml /app/datadog.yaml
 COPY ./scenarios/java_cpu_alloc/run.sh /app/run.sh

--- a/scenarios/java_cpu_alloc/Dockerfile
+++ b/scenarios/java_cpu_alloc/Dockerfile
@@ -52,9 +52,13 @@ FROM eclipse-temurin:25-jre AS runtime
 
 WORKDIR /app
 
-# Datadog java-profiler native agent (must match a released libjavaProfiler.so).
-ARG JAVA_PROFILER_VERSION=1.45.0
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# Datadog java-profiler native agent. Defaults to the latest GitHub release;
+# pass --build-arg JAVA_PROFILER_TAG=v_1.45.0 to pin a specific candidate
+# (e.g. to bisect a regression), matching how the other prof-correctness
+# profilers (ddprof's latest-rc tag, dd-trace-py/-rb/-js's unpinned/master
+# dependencies) default to latest with an explicit pin as the escape hatch.
+ARG JAVA_PROFILER_TAG=""
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && ARCH="$(dpkg --print-architecture)" \
     && case "$ARCH" in \
@@ -62,8 +66,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
          arm64) SO_ARCH=arm64 ;; \
          *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
        esac \
+    && TAG="${JAVA_PROFILER_TAG:-$(curl -fsSL https://api.github.com/repos/DataDog/java-profiler/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)}" \
+    && echo "Using java-profiler release ${TAG}" \
     && curl -fsSL -o /app/libjavaProfiler.so \
-       "https://github.com/DataDog/java-profiler/releases/download/v_${JAVA_PROFILER_VERSION}/libjavaProfiler_linux-${SO_ARCH}.so"
+       "https://github.com/DataDog/java-profiler/releases/download/${TAG}/libjavaProfiler_linux-${SO_ARCH}.so"
 
 COPY --from=jfr2pprof-build /build/jfr2pprof.jar /app/jfr2pprof.jar
 COPY --from=workload-build /build/classes /app

--- a/scenarios/java_cpu_alloc/Dockerfile
+++ b/scenarios/java_cpu_alloc/Dockerfile
@@ -45,8 +45,8 @@ RUN ./gradlew --no-daemon \
 
 FROM eclipse-temurin:25-jdk AS workload-build
 
-COPY ./scenarios/java_cpu_alloc/Workload.java /build/Workload.java
-RUN mkdir -p /build/classes && javac -d /build/classes /build/Workload.java
+COPY ./scenarios/java_cpu_alloc/CpuAllocWorkload.java /build/CpuAllocWorkload.java
+RUN mkdir -p /build/classes && javac -d /build/classes /build/CpuAllocWorkload.java
 
 FROM eclipse-temurin:25-jre AS runtime
 

--- a/scenarios/java_cpu_alloc/Dockerfile
+++ b/scenarios/java_cpu_alloc/Dockerfile
@@ -1,11 +1,11 @@
 # Multi-stage scenario for the Datadog java-profiler.
 #
-# Stage 1 builds jfr2pprof (btraceio/jafar, PROF-15286) from source, pinned to a
+# Stage 1 builds jfr2pprof (btraceio/jafar) from source, pinned to a
 # known-good commit, since it is not yet published as a Maven Central artifact
 # or a GitHub release asset.
 # Stage 2 downloads the java-profiler native agent from a GitHub release,
 # compiles the workload, runs it under the agent to record a .jfr, then
-# converts that recording to pprof via jfr2pprof + datadog.yaml (PROF-15289).
+# converts that recording to pprof via jfr2pprof + datadog.yaml.
 FROM eclipse-temurin:25-jdk AS jfr2pprof-build
 
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl \

--- a/scenarios/java_cpu_alloc/Workload.java
+++ b/scenarios/java_cpu_alloc/Workload.java
@@ -1,0 +1,77 @@
+/**
+ * Deterministic two-thread workload for the java_cpu_alloc prof-correctness scenario.
+ *
+ * One thread burns CPU in a tight loop (feeds the cpu-time profile), the other
+ * allocates byte[] continuously (feeds the allocation profile). Named Thread
+ * subclasses (not lambdas/anonymous classes) keep frame names stable across
+ * JDK versions for the expected_profile.json regexes.
+ */
+public class Workload {
+
+    static volatile boolean running = true;
+    static volatile long sink = 0;
+
+    static class CpuBurner extends Thread {
+        CpuBurner() {
+            super("cpu-burner");
+        }
+
+        @Override
+        public void run() {
+            while (running) {
+                sink += spin(100_000);
+            }
+        }
+
+        private long spin(int iterations) {
+            long acc = 0;
+            for (int i = 0; i < iterations; i++) {
+                acc += (long) i * i;
+            }
+            return acc;
+        }
+    }
+
+    static class AllocGenerator extends Thread {
+        // Batch-and-park keeps this thread's own CPU footprint low, so CPU
+        // samples stay dominated by CpuBurner while still producing a steady
+        // stream of allocations for the alloc-samples profile.
+        private static final int BATCH_SIZE = 64;
+        private static final long PARK_NANOS = 2_000_000L;
+
+        AllocGenerator() {
+            super("alloc-generator");
+        }
+
+        @Override
+        public void run() {
+            while (running) {
+                for (int i = 0; i < BATCH_SIZE; i++) {
+                    sink += allocate().length;
+                }
+                java.util.concurrent.locks.LockSupport.parkNanos(PARK_NANOS);
+            }
+        }
+
+        private byte[] allocate() {
+            return new byte[1024];
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        long durationSec = Long.parseLong(System.getenv().getOrDefault("EXECUTION_TIME_SEC", "10"));
+
+        CpuBurner cpuBurner = new CpuBurner();
+        AllocGenerator allocGenerator = new AllocGenerator();
+        cpuBurner.start();
+        allocGenerator.start();
+
+        Thread.sleep(durationSec * 1000L);
+        running = false;
+
+        cpuBurner.join();
+        allocGenerator.join();
+
+        System.out.println("sink=" + sink);
+    }
+}

--- a/scenarios/java_cpu_alloc/datadog.yaml
+++ b/scenarios/java_cpu_alloc/datadog.yaml
@@ -1,17 +1,7 @@
 # jfr2pprof mapping for the Datadog java-profiler.
 #
-# Staged here (java-profiler repo) per PROF-15289 pending PROF-15290, which will
-# land the actual prof-correctness scenario and move/reference this file from
-# its Dockerfile. Consumed by the vendor-neutral `jfr2pprof` tool in
-# btraceio/jafar (PROF-15286): `jfr2pprof --config datadog.yaml --output out.pprof rec.jfr`
-#
-# Ground truth verified against:
-#  - ddprof-lib/src/main/cpp/jfrMetadata.cpp (event/field definitions, authoritative)
-#  - ddprof-lib/src/main/cpp/event.h, itimer.cpp, objectSampler.cpp, flightRecorder.cpp
-#    (weight semantics)
-#  - a real recording taken with agent options
-#    `cpu=10ms,wall=50ms,memory=524288:aL` against a live CPU+alloc workload,
-#    inspected via jafar's JFR MCP tools (jfr_list_types/jfr_query).
+# Consumed by the vendor-neutral `jfr2pprof` tool in btraceio/jafar (PROF-15286):
+# `jfr2pprof --config datadog.yaml --output out.pprof rec.jfr`
 #
 # IMPORTANT: the scenario that uses this mapping MUST start the profiler with
 # cpu=10ms and wall=50ms to match the `scale` constants below. If the scenario

--- a/scenarios/java_cpu_alloc/datadog.yaml
+++ b/scenarios/java_cpu_alloc/datadog.yaml
@@ -1,0 +1,137 @@
+# jfr2pprof mapping for the Datadog java-profiler.
+#
+# Staged here (java-profiler repo) per PROF-15289 pending PROF-15290, which will
+# land the actual prof-correctness scenario and move/reference this file from
+# its Dockerfile. Consumed by the vendor-neutral `jfr2pprof` tool in
+# btraceio/jafar (PROF-15286): `jfr2pprof --config datadog.yaml --output out.pprof rec.jfr`
+#
+# Ground truth verified against:
+#  - ddprof-lib/src/main/cpp/jfrMetadata.cpp (event/field definitions, authoritative)
+#  - ddprof-lib/src/main/cpp/event.h, itimer.cpp, objectSampler.cpp, flightRecorder.cpp
+#    (weight semantics)
+#  - a real recording taken with agent options
+#    `cpu=10ms,wall=50ms,memory=524288:aL` against a live CPU+alloc workload,
+#    inspected via jafar's JFR MCP tools (jfr_list_types/jfr_query).
+#
+# IMPORTANT: the scenario that uses this mapping MUST start the profiler with
+# cpu=10ms and wall=50ms to match the `scale` constants below. If the scenario
+# changes those intervals, the `scale` values here must be updated to match
+# (jfr2pprof has no way to read jdk.ActiveSetting at runtime; scale is a fixed
+# per-mapping constant, not derived from the recording).
+
+frame:
+  format: "{class}.{method}"
+  includeLineNumbers: false
+
+profiles:
+  - type: cpu-time
+    event: datadog.ExecutionSample
+    stackField: stackTrace
+    values:
+      - name: cpu-samples
+        unit: count
+        field: "@count"
+      # CPU weight is always 1 (ITimer/CTimer/perf_events never set
+      # ExecutionEvent::_weight — see event.h default and itimer.cpp/
+      # ctimer_linux.cpp/perfEvents_linux.cpp, none assign _weight). One
+      # sample == one configured cpu interval of attributed CPU time.
+      - name: cpu-time
+        unit: nanoseconds
+        field: weight
+        scale: 10000000 # 10ms, must match the scenario's `cpu=` interval
+    labels:
+      - jfr: eventThread.osThreadId
+        pprof: "thread id"
+      - jfr: eventThread.javaName
+        pprof: "thread name"
+
+  - type: wall-time
+    event: datadog.MethodSample
+    stackField: stackTrace
+    values:
+      - name: wall-samples
+        unit: count
+        field: "@count"
+      # Unlike CPU, wall weight CAN exceed 1 (wallClock.cpp coalesces
+      # multiple missed intervals for blocked/waiting threads into a single
+      # recorded sample via consumeUnownedBlockedWeight()). Treating weight
+      # as a plain multiplier of the interval is an approximation of actual
+      # wall time represented, not an exact figure.
+      #
+      # CAVEAT: not empirically observed firing in the local macOS PoC
+      # recording (0 datadog.MethodSample events were produced despite
+      # wall=50ms being active — both workload threads stayed RUNNABLE for
+      # the whole run, so WallClock had no blocked/waiting samples to
+      # attribute). Field names/shape below are schema-verified against
+      # jfrMetadata.cpp only; re-validate weight values once this fires on a
+      # thread with genuine blocking (e.g. add I/O or lock contention to the
+      # scenario workload, or run on Linux CI).
+      - name: wall-time
+        unit: nanoseconds
+        field: weight
+        scale: 50000000 # 50ms, must match the scenario's `wall=` interval
+    labels:
+      - jfr: eventThread.osThreadId
+        pprof: "thread id"
+      - jfr: eventThread.javaName
+        pprof: "thread name"
+
+  - type: allocation
+    event: datadog.ObjectSample
+    stackField: stackTrace
+    values:
+      - name: alloc-samples
+        unit: count
+        field: "@count"
+      # KNOWN LIMITATION: the true unbiased allocation-volume estimator is
+      # `size * weight`, where weight = 1 / (1 - exp(-size / interval)) is
+      # the inverse-transform Poisson-thinning correction applied in
+      # objectSampler.cpp (larger objects are sampled more often, so their
+      # contribution must be down-weighted to estimate total bytes
+      # allocated). jfr2pprof's ValueSpec only supports a single field path
+      # times a static scale constant — it cannot multiply two runtime
+      # fields together. Mapping to raw `size` here is therefore a
+      # DIRECTIONALLY-CORRECT PROXY, not a bias-corrected byte estimate; it
+      # systematically undercounts allocation volume for larger object
+      # classes relative to `size * weight`. Revisit once jfr2pprof supports
+      # a product-of-fields value spec (tracked as a follow-up, not yet
+      # filed as a sub-task).
+      - name: alloc-size
+        unit: bytes
+        field: size
+    labels:
+      - jfr: eventThread.osThreadId
+        pprof: "thread id"
+      - jfr: eventThread.javaName
+        pprof: "thread name"
+      - jfr: objectClass.name.string
+        pprof: "class"
+
+  - type: live-heap
+    event: datadog.HeapLiveObject
+    stackField: stackTrace
+    values:
+      - name: live-objects
+        unit: count
+        field: "@count"
+      # Same product-of-fields limitation as allocation above: HeapLiveObject
+      # carries its own `weight` (float, computed in flightRecorder.cpp as
+      # (alloc.weight * alloc.size + skipped) / alloc.size — an average
+      # retained-weight per survivor, not directly bytes). Mapping to raw
+      # `size` is the same directionally-correct, bias-uncorrected proxy.
+      #
+      # CAVEAT: datadog.HeapLiveObject had 0 events in the local PoC
+      # recording (8s run, memory=524288:aL) — liveness tracking needs
+      # allocations to survive past a GC/liveness epoch, which the short
+      # workload didn't reach. Schema is verified against jfrMetadata.cpp
+      # only; re-validate field values on a longer-running scenario.
+      - name: live-size
+        unit: bytes
+        field: size
+    labels:
+      - jfr: eventThread.osThreadId
+        pprof: "thread id"
+      - jfr: eventThread.javaName
+        pprof: "thread name"
+      - jfr: objectClass.name.string
+        pprof: "class"

--- a/scenarios/java_cpu_alloc/datadog.yaml
+++ b/scenarios/java_cpu_alloc/datadog.yaml
@@ -1,6 +1,6 @@
 # jfr2pprof mapping for the Datadog java-profiler.
 #
-# Consumed by the vendor-neutral `jfr2pprof` tool in btraceio/jafar (PROF-15286):
+# Consumed by the vendor-neutral `jfr2pprof` tool in btraceio/jafar:
 # `jfr2pprof --config datadog.yaml --output out.pprof rec.jfr`
 #
 # IMPORTANT: the scenario that uses this mapping MUST start the profiler with

--- a/scenarios/java_cpu_alloc/datadog.yaml
+++ b/scenarios/java_cpu_alloc/datadog.yaml
@@ -47,15 +47,6 @@ profiles:
       # recorded sample via consumeUnownedBlockedWeight()). Treating weight
       # as a plain multiplier of the interval is an approximation of actual
       # wall time represented, not an exact figure.
-      #
-      # CAVEAT: not empirically observed firing in the local macOS PoC
-      # recording (0 datadog.MethodSample events were produced despite
-      # wall=50ms being active — both workload threads stayed RUNNABLE for
-      # the whole run, so WallClock had no blocked/waiting samples to
-      # attribute). Field names/shape below are schema-verified against
-      # jfrMetadata.cpp only; re-validate weight values once this fires on a
-      # thread with genuine blocking (e.g. add I/O or lock contention to the
-      # scenario workload, or run on Linux CI).
       - name: wall-time
         unit: nanoseconds
         field: weight
@@ -109,12 +100,6 @@ profiles:
       # (alloc.weight * alloc.size + skipped) / alloc.size — an average
       # retained-weight per survivor, not directly bytes). Mapping to raw
       # `size` is the same directionally-correct, bias-uncorrected proxy.
-      #
-      # CAVEAT: datadog.HeapLiveObject had 0 events in the local PoC
-      # recording (8s run, memory=524288:aL) — liveness tracking needs
-      # allocations to survive past a GC/liveness epoch, which the short
-      # workload didn't reach. Schema is verified against jfrMetadata.cpp
-      # only; re-validate field values on a longer-running scenario.
       - name: live-size
         unit: bytes
         field: size

--- a/scenarios/java_cpu_alloc/expected_profile.json
+++ b/scenarios/java_cpu_alloc/expected_profile.json
@@ -1,7 +1,7 @@
 {
   "test_name": "java_cpu_alloc",
   "scale_by_duration": true,
-  "note": "Validates the datadog.yaml jfr2pprof mapping (PROF-15289) end-to-end: cpu-samples and alloc-samples are the two profile types confirmed against a real recording; wall-time and live-heap are not asserted here (see datadog.yaml caveats). Stack regexes are method-qualified per frame.format ('{class}.{method}'); requires jfr2pprof >= 0.26.1 (fix for https://github.com/btraceio/jafar/issues/105, which had dropped method names from pprof Function.Name).",
+  "note": "Validates the datadog.yaml jfr2pprof mapping end-to-end: cpu-samples and alloc-samples are the two profile types confirmed against a real recording; wall-time and live-heap are not asserted here (see datadog.yaml caveats). Stack regexes are method-qualified per frame.format ('{class}.{method}'); requires jfr2pprof >= 0.26.1 (fix for https://github.com/btraceio/jafar/issues/105, which had dropped method names from pprof Function.Name).",
   "stacks": [
     {
       "profile-type": "cpu-samples",

--- a/scenarios/java_cpu_alloc/expected_profile.json
+++ b/scenarios/java_cpu_alloc/expected_profile.json
@@ -1,0 +1,39 @@
+{
+  "test_name": "java_cpu_alloc",
+  "scale_by_duration": true,
+  "note": "Validates the datadog.yaml jfr2pprof mapping (PROF-15289) end-to-end: cpu-samples and alloc-samples are the two profile types confirmed against a real recording; wall-time and live-heap are not asserted here (see datadog.yaml caveats). Stack regexes are method-qualified per frame.format ('{class}.{method}'); requires jfr2pprof >= 0.26.1 (fix for https://github.com/btraceio/jafar/issues/105, which had dropped method names from pprof Function.Name).",
+  "stacks": [
+    {
+      "profile-type": "cpu-samples",
+      "stack-content": [
+        {
+          "regular_expression": "^Workload\\$CpuBurner\\.run;Workload\\$CpuBurner\\.spin$",
+          "percent": 100,
+          "error_margin": 20,
+          "labels": [
+            {
+              "key": "thread name",
+              "values_regex": "cpu-burner"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "stack-content": [
+        {
+          "regular_expression": "^Workload\\$AllocGenerator\\.run;Workload\\$AllocGenerator\\.allocate$",
+          "percent": 100,
+          "error_margin": 20,
+          "labels": [
+            {
+              "key": "thread name",
+              "values_regex": "alloc-generator"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/java_cpu_alloc/expected_profile.json
+++ b/scenarios/java_cpu_alloc/expected_profile.json
@@ -7,7 +7,7 @@
       "profile-type": "cpu-samples",
       "stack-content": [
         {
-          "regular_expression": "^Workload\\$CpuBurner\\.run;Workload\\$CpuBurner\\.spin$",
+          "regular_expression": "^CpuAllocWorkload\\$CpuBurner\\.run;CpuAllocWorkload\\$CpuBurner\\.spin$",
           "percent": 100,
           "error_margin": 20,
           "labels": [
@@ -23,7 +23,7 @@
       "profile-type": "alloc-samples",
       "stack-content": [
         {
-          "regular_expression": "^Workload\\$AllocGenerator\\.run;Workload\\$AllocGenerator\\.allocate$",
+          "regular_expression": "^CpuAllocWorkload\\$AllocGenerator\\.run;CpuAllocWorkload\\$AllocGenerator\\.allocate$",
           "percent": 100,
           "error_margin": 20,
           "labels": [

--- a/scenarios/java_cpu_alloc/run.sh
+++ b/scenarios/java_cpu_alloc/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REC=/tmp/rec.jfr
+
+# wall-clock profiling intentionally not enabled: this scenario only exercises
+# and asserts on cpu-time/allocation, which is all datadog.yaml's cpu-time and
+# allocation mappings need.
+java "-agentpath:/app/libjavaProfiler.so=start,cpu=10ms,memory=524288:aL,jfr,file=${REC}" \
+    -cp /app Workload
+
+java -jar /app/jfr2pprof.jar --config /app/datadog.yaml --output /app/data/profile.pprof "${REC}"

--- a/scenarios/java_cpu_alloc/run.sh
+++ b/scenarios/java_cpu_alloc/run.sh
@@ -9,4 +9,4 @@ REC=/tmp/rec.jfr
 java "-agentpath:/app/libjavaProfiler.so=start,cpu=10ms,memory=524288:aL,jfr,file=${REC}" \
     -cp /app CpuAllocWorkload
 
-java -jar /app/jfr2pprof.jar --config /app/datadog.yaml --output /app/data/profile.pprof "${REC}"
+jbang jafar-tools-latest@btraceio jfr2pprof --config /app/datadog.yaml --output /app/data/profile.pprof "${REC}"

--- a/scenarios/java_cpu_alloc/run.sh
+++ b/scenarios/java_cpu_alloc/run.sh
@@ -7,6 +7,6 @@ REC=/tmp/rec.jfr
 # and asserts on cpu-time/allocation, which is all datadog.yaml's cpu-time and
 # allocation mappings need.
 java "-agentpath:/app/libjavaProfiler.so=start,cpu=10ms,memory=524288:aL,jfr,file=${REC}" \
-    -cp /app Workload
+    -cp /app CpuAllocWorkload
 
 java -jar /app/jfr2pprof.jar --config /app/datadog.yaml --output /app/data/profile.pprof "${REC}"


### PR DESCRIPTION
## Summary

- Adds `scenarios/java_cpu_alloc/`, the first `prof-correctness` scenario for the Datadog java-profiler (PROF-15290).
- Multi-stage Dockerfile builds `jfr2pprof` (btraceio/jafar, pinned to the `v0.26.1` release) from source, downloads the java-profiler native agent (v1.45.0) from its GitHub release, compiles a small deterministic workload, runs it under the agent to record a `.jfr`, then converts it to pprof via `jfr2pprof --config datadog.yaml`.
- Includes `datadog.yaml`, the jfr2pprof mapping for the Datadog java-profiler's JFR events (`datadog.ExecutionSample`, `datadog.MethodSample`, `datadog.ObjectSample`, `datadog.HeapLiveObject`), covering `cpu-time`, `wall-time`, `allocation`, and `live-heap`.
- The workload runs two threads: `CpuBurner` (busy-spins, dominates CPU samples) and `AllocGenerator` (batches allocations with a park, dominates allocation samples), so `expected_profile.json` can assert distinct, non-overlapping method-qualified folded stacks per thread.
- Only `cpu-samples`/`alloc-samples` are asserted here; `wall-time` and `live-heap` are mapped but not exercised by this workload (see caveats documented in `datadog.yaml`).

While building this, found and reported a real `jfr2pprof` bug (frame.format was parsed but never applied to `Function.Name`, collapsing all frames of a class into one node) — filed as [btraceio/jafar#105](https://github.com/btraceio/jafar/issues/105) and fixed upstream in `v0.26.1`, which this scenario is pinned to.

## Test plan

- [x] `TEST_SCENARIOS="java_cpu_alloc" TEST_RUN_SECS=10 go test -v -run TestScenarios ./...` passes locally: both `cpu-samples` and `alloc-samples` assertions succeed at 0% error.