### PR TITLE
[python_async_on_and_off_cpu] Add new check

### DIFF
--- a/scenarios/python_async_on_and_off_cpu_3.11/Dockerfile
+++ b/scenarios/python_async_on_and_off_cpu_3.11/Dockerfile
@@ -1,0 +1,37 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_async_on_and_off_cpu_3.11/main.py \
+    ./scenarios/python_async_on_and_off_cpu_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="30"
+
+ENV DD_PROFILING_ENABLED="true"
+
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="true"
+ 
+# 1% of the app's own CPU time
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_TARGET_OVERHEAD="1"
+
+# Maximum interval between stack samples in microseconds (max allowed is 100ms)
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="100000"
+
+# 1% CPU regardless of what the app is using
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_BASELINE="1"
+
+# Lookback window of 60 seconds for CPU usage
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_P_STABLE_WINDOW_S="60"
+
+# Use the 95th percentile of the CPU usage over the window to determine CPU usage
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_P_STABLE_PERCENTILE="95"
+
+# Enable fast memory copying
+ENV _DD_PROFILING_STACK_FAST_COPY="true"
+
+CMD python main.py

--- a/scenarios/python_async_on_and_off_cpu_3.11/README.md
+++ b/scenarios/python_async_on_and_off_cpu_3.11/README.md
@@ -1,0 +1,21 @@
+# python_async_on_and_off_cpu_3.11
+
+_**Note** This workload currently does not behave as expected._
+_We should only see a minority of CPU time attributed to `off_cpu_task`,_
+_in practice we see 99% of CPU time attributed to it. This is a fundamental_
+_limitation of tick-based profiling for spiky workloads, and something_
+_we plan to fix in the future with timer-based profiling._
+
+Verifies that the Python profiler correctly distinguishes CPU-time from wall-time
+for asyncio tasks that mix on-CPU and off-CPU work.
+
+All tasks run concurrently via `asyncio.gather` on a single thread:
+- **50 x off_cpu_task**: each loops 1000 times over `asyncio.sleep(0.001)`
+- **1 x on_cpu_task**: loops 100 times over `math.factorial(3500)` (CPU-bound)
+
+## Expected behavior
+
+- **wall-time**: dominated by `off_cpu_task` (~99%), since the 50 sleeping tasks
+  accumulate far more wall-clock time than the single CPU-bound task
+- **cpu-time**: `on_cpu_task` contributes a small but measurable share (~5%),
+  verifying that CPU-time is correctly attributed to asyncio task names

--- a/scenarios/python_async_on_and_off_cpu_3.11/expected_profile.json
+++ b/scenarios/python_async_on_and_off_cpu_3.11/expected_profile.json
@@ -1,0 +1,43 @@
+{
+  "test_name": "python_async_on_and_off_cpu",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression2": ".*",
+          "regular_expression": ".*main.*off_cpu_task.*",
+          "percent": 99,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "off_cpu_task"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*main.*on_cpu_task.*",
+          "percent": 5,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "on_cpu_task"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_async_on_and_off_cpu_3.11/main.py
+++ b/scenarios/python_async_on_and_off_cpu_3.11/main.py
@@ -1,0 +1,35 @@
+import asyncio
+import math
+
+from ddtrace.profiling import Profiler
+
+OFF_CPU_ITERATION_COUNT = 1_000
+OFF_CPU_TASK_COUNT = 50
+OFF_CPU_SLEEP_TIME = 0.001
+
+ON_CPU_ITERATION_COUNT = 100
+ON_CPU_TASK_COUNT = 1
+
+
+async def off_cpu_task() -> None:
+    for _ in range(OFF_CPU_ITERATION_COUNT):
+        await asyncio.sleep(OFF_CPU_SLEEP_TIME)
+
+
+async def on_cpu_task() -> None:
+    for _ in range(ON_CPU_ITERATION_COUNT):
+        math.factorial(3500)
+
+
+async def main() -> None:
+    await asyncio.gather(
+        *(asyncio.create_task(off_cpu_task(), name="off_cpu_task") for _ in range(OFF_CPU_TASK_COUNT)),
+        *(asyncio.create_task(on_cpu_task(), name="on_cpu_task") for _ in range(ON_CPU_TASK_COUNT)),
+    )
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    asyncio.run(main())

--- a/scenarios/python_async_on_and_off_cpu_3.11/requirements.txt
+++ b/scenarios/python_async_on_and_off_cpu_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
## What is this PR?

This PR adds a new correctness check where we have many off-CPU asyncio tasks and one on-CPU asyncio task. 

In theory, we should see 100% of the CPU time attributed to the one on-CPU task and ~100% of the wall time attributed to the off CPU tasks (they're sleeping for much longer than the on-CPU task is computing for). 

In practice, however, for now, due to the bias we know, ~100% CPU time is attributed to off-CPU tasks (which is clearly stated in the `README.md`. 

This should get much better once we have timer-based profiling.