### PR TITLE
[python_sample_count] Add new check

### DIFF
--- a/scenarios/python_safe_point_bias_3.11/README.md
+++ b/scenarios/python_safe_point_bias_3.11/README.md
@@ -10,6 +10,7 @@ Verifies that the Python profiler correctly attributes CPU time to `slow_method`
 def empty_method() -> None:
     pass
 
+
 def slow_method() -> None:
     while time() < end_time:
         x = "h" + "e" + "l" + "l" + "o" + ","

--- a/scenarios/python_sample_count_3.11/Dockerfile
+++ b/scenarios/python_sample_count_3.11/Dockerfile
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE="prof-python-3.11"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_sample_count_3.11/main.py \
+    ./scenarios/python_sample_count_3.11/requirements.txt \
+    /app/
+RUN chmod 644 /app/*
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC="30"
+
+ENV DD_PROFILING_ENABLED="true"
+
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="false"
+
+# Enable fast memory copying
+ENV _DD_PROFILING_STACK_FAST_COPY="true"
+
+CMD python main.py

--- a/scenarios/python_sample_count_3.11/README.md
+++ b/scenarios/python_sample_count_3.11/README.md
@@ -1,0 +1,20 @@
+# python_sample_count_3.11
+
+Verifies that the stack-sampling adaptive sampler produces a reasonable number of
+`wall-samples` under its configured overhead target.
+
+## Workload
+
+Uses `asyncio.gather` to run many concurrent coroutines:
+- **500 off-cpu tasks**: each calls `asyncio.sleep(0.0001)` 1000 times
+- **10 on-cpu tasks**: each calls `math.factorial` 10 times
+
+All coroutines are gathered in a single `asyncio.run` call.
+
+## Expected behavior
+
+- **wall-samples**: the total number of raw stack samples captured over the run is checked
+  against a reference value (`value-matching-sum` = 40000) with a wide error margin (20%),
+  since the adaptive sampler's interval reacts to CPU usage and host scheduling noise.
+  This is a coarse regression check (e.g. catches the sampler firing far too often/rarely),
+  not an exact count.

--- a/scenarios/python_sample_count_3.11/expected_profile.json
+++ b/scenarios/python_sample_count_3.11/expected_profile.json
@@ -1,0 +1,16 @@
+{
+  "test_name": "python_sample_count",
+  "stacks": [
+    {
+      "profile-type": "wall-samples",
+      "stack-content": [
+        {
+          "regular_expression": ".*"
+        }
+      ],
+      "value-matching-sum": 40000,
+      "error-margin": 20
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_sample_count_3.11/main.py
+++ b/scenarios/python_sample_count_3.11/main.py
@@ -1,0 +1,34 @@
+import asyncio
+import math
+import time
+
+from ddtrace.profiling import Profiler
+
+SLEEP_TIME = 0.0001
+SLEEP_COUNT = 1_000
+ON_CPU_COUNT = 10
+OFF_CPU_COUNT = 500
+
+
+async def off_cpu_task() -> None:
+    for _ in range(SLEEP_COUNT):
+        await asyncio.sleep(SLEEP_TIME)
+
+
+async def on_cpu_task() -> None:
+    for x in range(ON_CPU_COUNT):
+        math.factorial(x)
+
+
+async def main() -> None:
+    await asyncio.gather(*(off_cpu_task() for _ in range(OFF_CPU_COUNT)), *(on_cpu_task() for _ in range(ON_CPU_COUNT)))
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    start = time.time()
+    asyncio.run(main())
+    end = time.time()
+    print(f"Run took {end - start} seconds")

--- a/scenarios/python_sample_count_3.11/requirements.txt
+++ b/scenarios/python_sample_count_3.11/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace

--- a/scenarios/python_spiky_3.11/Dockerfile
+++ b/scenarios/python_spiky_3.11/Dockerfile
@@ -10,14 +10,28 @@ WORKDIR /app
 
 RUN pip install -r requirements.txt
 
-ENV EXECUTION_TIME_SEC="20"
+ENV EXECUTION_TIME_SEC="30"
 
-# Leave empty to use ddtrace defaults.
-# _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_TARGET_OVERHEAD controls the fraction of
-# CPU (0-100) the profiler is allowed to consume; lower means sparser sampling.
-# _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US is the hard upper bound
-# on the interval between stack samples in microseconds; higher means sparser sampling.
+ENV DD_PROFILING_ENABLED="true"
+
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_ENABLED="true"
+ 
+# 1% of the app's own CPU time
 ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_TARGET_OVERHEAD="1"
-ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="10000"
+
+# Maximum interval between stack samples in microseconds (max allowed is 100ms)
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_MAX_INTERVAL_US="100000"
+
+# 1% CPU regardless of what the app is using
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_BASELINE="1"
+
+# Lookback window of 60 seconds for CPU usage
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_P_STABLE_WINDOW_S="60"
+
+# Use the 95th percentile of the CPU usage over the window to determine CPU usage
+ENV _DD_PROFILING_STACK_ADAPTIVE_SAMPLING_P_STABLE_PERCENTILE="95"
+
+# Enable fast memory copying
+ENV _DD_PROFILING_STACK_FAST_COPY="true"
 
 CMD python main.py


### PR DESCRIPTION
## What is this PR?

This PR adds a check for the Python Profiler to ensure we don't emit absurd amounts of wall time samples when there are many tasks / greenlets in the process. 

Currently, the few seconds-long script generates about 50k samples, due to the 500+10 tasks that exist. We are currently working on getting that number down by intelligently selecting which tasks to sample.