### PR TITLE
feat(python): add live_heap 3.14/3.15 gate scenarios (PROF-15511)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       # exclude rather than a lookahead baked into test_scenarios.
       # Additional wheel-only 3.14 dirs (e.g. live_heap) are added to this list
       # when those scenarios land.
-      test_scenarios_exclude: '_3\.15$|^python_downstream_gate$'
+      test_scenarios_exclude: '_3\.15$|^python_live_heap_3\.14$|^python_downstream_gate$'
     secrets: inherit
   full_host:
     uses: ./.github/workflows/test.yml

--- a/scenarios/python_downstream_gate/README.md
+++ b/scenarios/python_downstream_gate/README.md
@@ -1,53 +1,30 @@
 # Python downstream gate (dd-trace-py)
 
-Paired **3.14 (baseline)** and **3.15 (candidate)** prof-correctness scenarios
-exercise the Python profiling stack for the 3.14 → 3.15 migration. They are the
-intended default set when dd-trace-py triggers downstream CI on profiling changes.
-
-**Scenarios land in follow-up PRs** (core families first, then feature-specific
-pairs). This directory is an index only — not a runnable scenario.
+Two prof-correctness scenarios exercise **persistent live-heap** profiling on
+**3.14 (baseline)** and **3.15 (candidate)**. Both dirs are **wheel-only**
+(persistent live-heap is not in a published PyPI release yet).
 
 ## Scenarios
 
-| Family | 3.14 (baseline) | 3.15 (candidate) | PR |
-|--------|-----------------|---------------------|-----|
-| _(pending)_ | — | — | Core scenarios in follow-up PRs |
+| Family | 3.14 (baseline) | 3.15 (candidate) |
+|--------|-------------------|------------------|
+| live-heap | `python_live_heap_3.14` | `python_live_heap_3.15` |
 
 ## Default downstream regexp
 
-Once scenarios are added, dd-trace-py should pass an explicit regexp (not the
-downstream workflow default of `python.*`). The regexp grows as families merge;
-see each PR for the current value.
+```
+python_live_heap_3\.(14|15)
+```
 
-Override via `workflow_dispatch` → `test_scenarios`, or when triggering
-[`downstream-python.yml`](../../.github/workflows/downstream-python.yml) manually.
+## CI exclude
 
-## Wheel install
-
-Every scenario builds against a **dd-trace-py wheel** via `DDTRACE_INSTALL_URL`
-(as `downstream-python.yml` does:
-`https://dd-trace-py-builds.s3.amazonaws.com/<sha>/install.sh`), pre-installed in
-the base image.
-
-- **All `*_3.15` folders** — PyPI wheels may not be published for 3.15 yet;
-  excluded from prof-correctness `main` CI (see `test_scenarios_exclude` in
-  [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)).
-- **Wheel-only 3.14 folders** — scenarios that depend on unreleased ddtrace
-  features are also excluded from `main` CI until the feature ships.
+Both folders require `DDTRACE_INSTALL_URL`. `python_live_heap_3.14` is also
+listed in [`ci.yml`](../../.github/workflows/ci.yml) `test_scenarios_exclude`
+until the feature ships in a PyPI release.
 
 ## Local run
 
 ```sh
 export DDTRACE_INSTALL_URL="https://dd-trace-py-builds.s3.amazonaws.com/<commit-sha>/install.sh"
-TEST_SCENARIOS='<gate-regexp>' go test -v -run TestScenarios
+TEST_SCENARIOS='python_live_heap_3\.(14|15)' go test -v -run TestScenarios
 ```
-
-## Gate lifecycle
-
-This gate tests the **migration delta** (3.14 → 3.15). It is time-boxed: retire
-the paired 14v15 framing at 3.15 GA and fold workloads into steady-state
-prof-correctness on {oldest, newest} supported Python versions.
-
-## Further reading
-
-- prof-correctness downstream wiring: [README](../../README.md#downstream-from-dd-trace-py)

--- a/scenarios/python_live_heap_3.14/Dockerfile
+++ b/scenarios/python_live_heap_3.14/Dockerfile
@@ -1,0 +1,25 @@
+ARG BASE_IMAGE="prof-python-3.14"
+FROM $BASE_IMAGE
+
+# ddtrace is pre-installed in the base image when DDTRACE_INSTALL_URL is set
+# (dd-trace-py downstream CI). Do not pip-install from PyPI here: the persistent
+# live-heap profile is recent and may not be in a published release yet, so this
+# scenario runs against the just-built wheel until it ships.
+COPY ./scenarios/python_live_heap_3.14/main.py /app/main.py
+WORKDIR /app
+
+ENV EXECUTION_TIME_SEC="15"
+# Enable the live-heap profiler and make the snapshot the deliverable.
+ENV DD_PROFILING_MEMORY_ENABLED=true
+ENV DD_PROFILING_HEAP_ENABLED=true
+# Sample interval == object size -> ~one sample per object -> stable
+# per-stack proportions for both heap-space and heap-live-samples.
+ENV DD_PROFILING_HEAP_SAMPLE_SIZE=16384
+# Export several snapshots during the run so the persistent live set is
+# exercised across upload intervals (not just at shutdown).
+ENV DD_PROFILING_UPLOAD_INTERVAL=5
+# Isolate the heap profiler so other collectors don't add noise.
+ENV DD_PROFILING_STACK_ENABLED=false
+ENV DD_PROFILING_LOCK_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_live_heap_3.14/README.md
+++ b/scenarios/python_live_heap_3.14/README.md
@@ -1,0 +1,51 @@
+## Live-Heap Profiling (3.14 baseline)
+
+Validates that the Datadog Python profiler's **persistent live-heap profile**
+correctly reports the set of live (still-allocated) sampled objects. This is the
+**3.14 baseline** half of the `3.14 -> 3.15` migration pair (see
+`python_live_heap_3.15`).
+
+Unlike `alloc-space`/`alloc-samples` (which count every allocation over the
+interval), the live-heap profile is a running snapshot of what is *currently
+live*: allocations are added when sampled and subtracted when freed, and the
+snapshot is exported non-destructively on every upload. It is attached as a
+second pprof (`<prefix>.<pid>.<seq>.heap.pprof`) alongside the primary profile.
+
+## Test Application
+
+`main.py` retains a known live set for the whole run, split into two
+distinctly-named call sites that allocate **equal-size** objects (16 KiB) and
+differ only in count:
+
+- `retain_major` - 1,600 objects (~25 MiB, ~80% of the live set)
+- `retain_minor` -   400 objects (~6 MiB, ~20% of the live set)
+
+Equal sizes mean the 80/20 split holds for both metrics the live-heap profile
+reports: `heap-space` (live bytes = count x size) and `heap-live-samples` (live
+object count). It uses `bytes` (`PyObject_Malloc`, the OBJ allocator domain) so
+the heap profiler tracks the objects identically across versions, independent of
+the `DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED` toggle (`bytearray` moved OBJ -> MEM
+in 3.13). The objects are held alive while the process idles through several
+upload intervals (`DD_PROFILING_UPLOAD_INTERVAL=5`), so each exported heap
+snapshot contains the full live set.
+
+## Expected Profile
+
+Assertions run against the heap snapshot pprof only (selected with
+`pprof-regex`). `DD_PROFILING_HEAP_SAMPLE_SIZE=16384` (== object size) yields
+roughly one sample per object, keeping the per-stack proportions stable.
+
+- `heap-space` (live bytes):
+  - `^<module>;Target.run;Target.retain_major$` ~= 80%
+  - `^<module>;Target.run;Target.retain_minor$` ~= 20%
+- `heap-live-samples` (live object count): same ~80/20 split.
+
+`allow_first_profile_failure` tolerates the first snapshot, which may be taken
+before the live set is fully built.
+
+## Notes
+
+The persistent live-heap profile is recent, so this scenario runs against a
+ddtrace build that includes it (via `DDTRACE_INSTALL_URL` pointing at a
+dd-trace-py S3 wheel) rather than a PyPI release. It is excluded from
+prof-correctness `main` CI until the feature ships in a release.

--- a/scenarios/python_live_heap_3.14/expected_profile.json
+++ b/scenarios/python_live_heap_3.14/expected_profile.json
@@ -1,0 +1,43 @@
+{
+  "test_name": "python_live_heap",
+  "note": "Persistent live-heap profile. Assertions run against the separate heap snapshot pprof (<prefix>.<pid>.<seq>.heap.pprof), selected via pprof-regex. heap-space = live bytes, heap-live-samples = live object count. retain_major/retain_minor allocate equal-size objects in an 80/20 count split, so both metrics show the same ~80/20 proportions. Thread-name labels are intentionally not asserted: the heap profiler tags samples with the numeric OS thread id, which varies per run.",
+  "pprof-regex": ".*heap\\.pprof",
+  "scale_by_duration": false,
+  "allow_first_profile_failure": true,
+  "stacks": [
+    {
+      "profile-type": "heap-space",
+      "stack-content": [
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_major$",
+          "percent": 80,
+          "error_margin": 10,
+          "labels": []
+        },
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_minor$",
+          "percent": 20,
+          "error_margin": 10,
+          "labels": []
+        }
+      ]
+    },
+    {
+      "profile-type": "heap-live-samples",
+      "stack-content": [
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_major$",
+          "percent": 80,
+          "error_margin": 12,
+          "labels": []
+        },
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_minor$",
+          "percent": 20,
+          "error_margin": 12,
+          "labels": []
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_live_heap_3.14/main.py
+++ b/scenarios/python_live_heap_3.14/main.py
@@ -1,0 +1,55 @@
+import os
+import time
+
+from ddtrace.profiling import Profiler
+
+# Allocations are held at module scope so they stay live for the whole process
+# and therefore appear in every live-heap snapshot the profiler exports.
+LIVE: list = []
+
+# Two distinctly-named call sites that retain a known live set. Both allocate
+# the SAME object size and differ only in count, so the 80/20 split holds for
+# both metrics the live-heap profile reports:
+#   - heap-space        (live bytes)  -> count * size  -> 80/20
+#   - heap-live-samples (live objects) -> count        -> 80/20
+# We use ``bytes`` (PyObject_Malloc / OBJ domain), which the heap profiler
+# tracks identically across Python versions and independent of the MEM-domain
+# toggle (``bytearray`` moved OBJ -> MEM in 3.13). This keeps the scenario a
+# clean live-heap check across the 3.14 -> 3.15 migration.
+OBJ_SIZE = 16384  # 16 KiB, well above the pymalloc small-object threshold
+N_MAJOR = 1600  # ~80% of the live set  (1600 * 16 KiB ~= 25 MiB)
+N_MINOR = 400  # ~20% of the live set  ( 400 * 16 KiB ~=  6 MiB)
+
+
+class Target:
+    def __init__(self) -> None:
+        self.live: list = []
+
+    def run(self, hold_seconds: float) -> None:
+        self.retain_major()
+        self.retain_minor()
+        # Keep the live set alive across several upload intervals so each
+        # exported heap snapshot contains the full set.
+        deadline = time.monotonic() + hold_seconds
+        while time.monotonic() < deadline:
+            time.sleep(0.5)
+
+    def retain_major(self) -> None:
+        for _ in range(N_MAJOR):
+            self.live.append(bytes(OBJ_SIZE))
+
+    def retain_minor(self) -> None:
+        for _ in range(N_MINOR):
+            self.live.append(bytes(OBJ_SIZE))
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()  # As early as possible so the allocations below are sampled.
+
+    execution_time = int(os.environ.get("EXECUTION_TIME_SEC", "15"))
+    target = Target()
+    LIVE.append(target)
+    target.run(hold_seconds=execution_time)
+
+    prof.stop()

--- a/scenarios/python_live_heap_3.14/requirements.txt
+++ b/scenarios/python_live_heap_3.14/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace

--- a/scenarios/python_live_heap_3.15/Dockerfile
+++ b/scenarios/python_live_heap_3.15/Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE="prof-python-3.15"
+FROM $BASE_IMAGE
+
+# ddtrace is pre-installed in the base image when DDTRACE_INSTALL_URL is set
+# (dd-trace-py downstream CI). Do not pip-install here — PyPI wheels may not
+# exist for 3.15 yet, and the persistent live-heap profile is recent.
+COPY ./scenarios/python_live_heap_3.15/main.py /app/main.py
+WORKDIR /app
+
+ENV EXECUTION_TIME_SEC="15"
+# Enable the live-heap profiler and make the snapshot the deliverable.
+ENV DD_PROFILING_MEMORY_ENABLED=true
+ENV DD_PROFILING_HEAP_ENABLED=true
+# Sample interval == object size -> ~one sample per object -> stable
+# per-stack proportions for both heap-space and heap-live-samples.
+ENV DD_PROFILING_HEAP_SAMPLE_SIZE=16384
+# Export several snapshots during the run so the persistent live set is
+# exercised across upload intervals (not just at shutdown).
+ENV DD_PROFILING_UPLOAD_INTERVAL=5
+# Isolate the heap profiler so other collectors don't add noise.
+ENV DD_PROFILING_STACK_ENABLED=false
+ENV DD_PROFILING_LOCK_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_live_heap_3.15/README.md
+++ b/scenarios/python_live_heap_3.15/README.md
@@ -1,0 +1,52 @@
+## Live-Heap Profiling (3.15 candidate)
+
+Validates that the Datadog Python profiler's **persistent live-heap profile**
+correctly reports the set of live (still-allocated) sampled objects. This is the
+**3.15 candidate** half of the `3.14 -> 3.15` migration pair (see
+`python_live_heap_3.14`).
+
+Unlike `alloc-space`/`alloc-samples` (which count every allocation over the
+interval), the live-heap profile is a running snapshot of what is *currently
+live*: allocations are added when sampled and subtracted when freed, and the
+snapshot is exported non-destructively on every upload. It is attached as a
+second pprof (`<prefix>.<pid>.<seq>.heap.pprof`) alongside the primary profile.
+
+## Test Application
+
+`main.py` retains a known live set for the whole run, split into two
+distinctly-named call sites that allocate **equal-size** objects (16 KiB) and
+differ only in count:
+
+- `retain_major` - 1,600 objects (~25 MiB, ~80% of the live set)
+- `retain_minor` -   400 objects (~6 MiB, ~20% of the live set)
+
+Equal sizes mean the 80/20 split holds for both metrics the live-heap profile
+reports: `heap-space` (live bytes = count x size) and `heap-live-samples` (live
+object count). It uses `bytes` (`PyObject_Malloc`, the OBJ allocator domain) so
+the heap profiler tracks the objects identically across versions, independent of
+the `DD_PROFILING_MEMORY_MEM_DOMAIN_ENABLED` toggle (`bytearray` moved OBJ -> MEM
+in 3.13). The objects are held alive while the process idles through several
+upload intervals (`DD_PROFILING_UPLOAD_INTERVAL=5`), so each exported heap
+snapshot contains the full live set.
+
+## Expected Profile
+
+Assertions run against the heap snapshot pprof only (selected with
+`pprof-regex`). `DD_PROFILING_HEAP_SAMPLE_SIZE=16384` (== object size) yields
+roughly one sample per object, keeping the per-stack proportions stable.
+
+- `heap-space` (live bytes):
+  - `^<module>;Target.run;Target.retain_major$` ~= 80%
+  - `^<module>;Target.run;Target.retain_minor$` ~= 20%
+- `heap-live-samples` (live object count): same ~80/20 split.
+
+`allow_first_profile_failure` tolerates the first snapshot, which may be taken
+before the live set is fully built.
+
+## Notes
+
+Requires a **dd-trace-py wheel** at image build time (set `DDTRACE_INSTALL_URL`,
+as `downstream-python.yml` does). Do **not** `pip install ddtrace` from PyPI —
+3.15 wheels may not be published yet. Excluded from prof-correctness `main` CI
+until 3.15 wheels are generally available; runs via the dd-trace-py downstream
+gate.

--- a/scenarios/python_live_heap_3.15/expected_profile.json
+++ b/scenarios/python_live_heap_3.15/expected_profile.json
@@ -1,0 +1,43 @@
+{
+  "test_name": "python_live_heap",
+  "note": "Persistent live-heap profile. Assertions run against the separate heap snapshot pprof (<prefix>.<pid>.<seq>.heap.pprof), selected via pprof-regex. heap-space = live bytes, heap-live-samples = live object count. retain_major/retain_minor allocate equal-size objects in an 80/20 count split, so both metrics show the same ~80/20 proportions. Thread-name labels are intentionally not asserted: the heap profiler tags samples with the numeric OS thread id, which varies per run.",
+  "pprof-regex": ".*heap\\.pprof",
+  "scale_by_duration": false,
+  "allow_first_profile_failure": true,
+  "stacks": [
+    {
+      "profile-type": "heap-space",
+      "stack-content": [
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_major$",
+          "percent": 80,
+          "error_margin": 10,
+          "labels": []
+        },
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_minor$",
+          "percent": 20,
+          "error_margin": 10,
+          "labels": []
+        }
+      ]
+    },
+    {
+      "profile-type": "heap-live-samples",
+      "stack-content": [
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_major$",
+          "percent": 80,
+          "error_margin": 12,
+          "labels": []
+        },
+        {
+          "regular_expression": "^<module>;Target\\.run;Target\\.retain_minor$",
+          "percent": 20,
+          "error_margin": 12,
+          "labels": []
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_live_heap_3.15/main.py
+++ b/scenarios/python_live_heap_3.15/main.py
@@ -1,0 +1,55 @@
+import os
+import time
+
+from ddtrace.profiling import Profiler
+
+# Allocations are held at module scope so they stay live for the whole process
+# and therefore appear in every live-heap snapshot the profiler exports.
+LIVE: list = []
+
+# Two distinctly-named call sites that retain a known live set. Both allocate
+# the SAME object size and differ only in count, so the 80/20 split holds for
+# both metrics the live-heap profile reports:
+#   - heap-space        (live bytes)  -> count * size  -> 80/20
+#   - heap-live-samples (live objects) -> count        -> 80/20
+# We use ``bytes`` (PyObject_Malloc / OBJ domain), which the heap profiler
+# tracks identically across Python versions and independent of the MEM-domain
+# toggle (``bytearray`` moved OBJ -> MEM in 3.13). This keeps the scenario a
+# clean live-heap check across the 3.14 -> 3.15 migration.
+OBJ_SIZE = 16384  # 16 KiB, well above the pymalloc small-object threshold
+N_MAJOR = 1600  # ~80% of the live set  (1600 * 16 KiB ~= 25 MiB)
+N_MINOR = 400  # ~20% of the live set  ( 400 * 16 KiB ~=  6 MiB)
+
+
+class Target:
+    def __init__(self) -> None:
+        self.live: list = []
+
+    def run(self, hold_seconds: float) -> None:
+        self.retain_major()
+        self.retain_minor()
+        # Keep the live set alive across several upload intervals so each
+        # exported heap snapshot contains the full set.
+        deadline = time.monotonic() + hold_seconds
+        while time.monotonic() < deadline:
+            time.sleep(0.5)
+
+    def retain_major(self) -> None:
+        for _ in range(N_MAJOR):
+            self.live.append(bytes(OBJ_SIZE))
+
+    def retain_minor(self) -> None:
+        for _ in range(N_MINOR):
+            self.live.append(bytes(OBJ_SIZE))
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()  # As early as possible so the allocations below are sampled.
+
+    execution_time = int(os.environ.get("EXECUTION_TIME_SEC", "15"))
+    target = Target()
+    LIVE.append(target)
+    target.run(hold_seconds=execution_time)
+
+    prof.stop()

--- a/scenarios/python_live_heap_3.15/requirements.txt
+++ b/scenarios/python_live_heap_3.15/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace


### PR DESCRIPTION
**Prev:** [#165](https://github.com/DataDog/prof-correctness/pull/165) | **Parallel:** [#166](https://github.com/DataDog/prof-correctness/pull/166), [#167](https://github.com/DataDog/prof-correctness/pull/167)

## Motivation

Persistent **live-heap** profiling needs dedicated gate scenarios. Both Python versions require a dd-trace-py wheel with live-heap support — not yet in mainline CI images.

## Summary

Adds paired **`python_live_heap_3.14/3.15`** scenarios:

- Workload produces persistent live-heap snapshot profiles
- Both dirs are **wheel-only** (`DDTRACE_INSTALL_URL`)
- `python_live_heap_3.14` added to `ci.yml` `test_scenarios_exclude` (no wheel in default CI)
- Gate regexp for optional runs: `python_live_heap_3\.(14|15)`

Stacks on `vlad/gate-infra` (PR-0).

> **Hold merge** until a dd-trace-py wheel with persistent live-heap is available for downstream CI.

## Test plan

- [x] `go test -run TestSchemaValidation`
- [ ] Downstream gate with `DDTRACE_INSTALL_URL` (blocked on wheel)

