### PR TITLE
feat(python): add alloc gate scenarios for 3.14/3.15 migration (PROF-15511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Both use [dd-octo-sts](https://github.com/DataDog/dd-octo-sts-action) (`dd-trace
 **Inputs:**
 
 - `dd_trace_py_commit_sha` — commit to test (required)
-- `test_scenarios` — regexp passed to `TEST_SCENARIOS` (dd-trace-py passes the [8-scenario 3.14/3.15 migration gate](scenarios/python_downstream_gate/README.md); the downstream workflow default alone is `python.*`)
+- `test_scenarios` — regexp passed to `TEST_SCENARIOS` (dd-trace-py passes the [10-scenario 3.14/3.15 migration gate](scenarios/python_downstream_gate/README.md); the downstream workflow default alone is `python.*`)
 
 ## Creating new tests 
 

--- a/scenarios/python_alloc_3.14/Dockerfile
+++ b/scenarios/python_alloc_3.14/Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE="prof-python-3.14"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_alloc_3.14/requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
+
+COPY ./scenarios/python_alloc_3.14/main.py /app/main.py
+WORKDIR /app
+
+ENV DD_PROFILING_STACK_ENABLED=false
+ENV DD_PROFILING_LOCK_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_alloc_3.14/README.md
+++ b/scenarios/python_alloc_3.14/README.md
@@ -1,9 +1,9 @@
 ## Allocation profiling (3.14 baseline)
 
 Validates that the Datadog Python profiler's **memory collector** reports
-`alloc-space` and `alloc-samples` with correct call stacks and `thread name`
-labels. This is the **3.14 baseline** half of the `3.14 -> 3.15` migration pair
-(see `python_alloc_3.15`).
+`alloc-space` and `alloc-samples` with correct call stacks on Python 3.14
+(`Target.run` / `Target.allocate_memory_*` frames). This is the **3.14 baseline**
+half of the `3.14 -> 3.15` migration pair (see `python_alloc_3.15`).
 
 Reuses the workload from `scenarios/python_basic_memory_3.11`: two allocation
 sites with a 1:3 byte ratio (`allocate_memory_1` / `allocate_memory_2`).
@@ -11,8 +11,10 @@ Stack and lock collectors are disabled to isolate allocation samples.
 
 ## Expected profile
 
-Assertions match `python_basic_memory_3.11` (stable sampling proportions for
-`alloc-samples` and `alloc-space`).
+On 3.14, alloc stacks use `Target.method` frames (not bare `run;allocate_memory_*`).
+Alloc profiles use numeric thread IDs, so assertions omit `thread name` labels.
+Sampling proportions follow `python_basic_memory_3.11` (stable `alloc-samples`
+and `alloc-space` ratios).
 
 ## Notes
 

--- a/scenarios/python_alloc_3.14/README.md
+++ b/scenarios/python_alloc_3.14/README.md
@@ -1,0 +1,20 @@
+## Allocation profiling (3.14 baseline)
+
+Validates that the Datadog Python profiler's **memory collector** reports
+`alloc-space` and `alloc-samples` with correct call stacks and `thread name`
+labels. This is the **3.14 baseline** half of the `3.14 -> 3.15` migration pair
+(see `python_alloc_3.15`).
+
+Reuses the workload from `scenarios/python_basic_memory_3.11`: two allocation
+sites with a 1:3 byte ratio (`allocate_memory_1` / `allocate_memory_2`).
+Stack and lock collectors are disabled to isolate allocation samples.
+
+## Expected profile
+
+Assertions match `python_basic_memory_3.11` (stable sampling proportions for
+`alloc-samples` and `alloc-space`).
+
+## Notes
+
+The 3.14 scenario runs on prof-correctness `main` CI (PyPI ddtrace). The 3.15
+candidate runs only via the dd-trace-py downstream gate (`DDTRACE_INSTALL_URL`).

--- a/scenarios/python_alloc_3.14/expected_profile.json
+++ b/scenarios/python_alloc_3.14/expected_profile.json
@@ -1,0 +1,127 @@
+{
+  "test_name": "python_alloc_3.14",
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
+          "percent": 35,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
+          "percent": 45,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^.*__init__;.*grow_list.*$",
+          "percent": 19,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
+          "percent": 25,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
+          "percent": 75,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^.*grow_list.*$",
+          "percent": 3,
+          "error_margin": 3,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_alloc_3.14/expected_profile.json
+++ b/scenarios/python_alloc_3.14/expected_profile.json
@@ -7,58 +7,14 @@
       "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
-          "percent": 35,
-          "error_margin": 5,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "alloc-samples",
-      "pprof-regex": "",
-      "stack-content": [
+          "regular_expression": "^<module>;Target\\.run;Target\\.allocate_memory_1$",
+          "percent": 33,
+          "error_margin": 10
+        },
         {
-          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
-          "percent": 45,
-          "error_margin": 5,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "alloc-samples",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": "^.*__init__;.*grow_list.*$",
-          "percent": 19,
-          "error_margin": 5,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
+          "regular_expression": "^<module>;Target\\.run;Target\\.allocate_memory_2$",
+          "percent": 44,
+          "error_margin": 10
         }
       ]
     },
@@ -67,58 +23,14 @@
       "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
-          "percent": 25,
-          "error_margin": 5,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "alloc-space",
-      "pprof-regex": "",
-      "stack-content": [
+          "regular_expression": "^<module>;Target\\.run;Target\\.allocate_memory_1$",
+          "percent": 30,
+          "error_margin": 10
+        },
         {
-          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
-          "percent": 75,
-          "error_margin": 5,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "alloc-space",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": "^.*grow_list.*$",
-          "percent": 3,
-          "error_margin": 3,
-          "labels": [
-            {
-              "key": "thread name",
-              "values": [
-                "MainThread"
-              ],
-              "values_regex": ""
-            }
-          ]
+          "regular_expression": "^<module>;Target\\.run;Target\\.allocate_memory_2$",
+          "percent": 40,
+          "error_margin": 10
         }
       ]
     }

--- a/scenarios/python_alloc_3.14/main.py
+++ b/scenarios/python_alloc_3.14/main.py
@@ -1,0 +1,33 @@
+from ddtrace.profiling import Profiler
+
+
+class Target:
+    def __init__(self) -> None:
+        self.memory: list[bytearray | None] = []
+        self.index = 0
+        self.grow_list(target=int(1e6))
+
+    def run(self) -> None:
+        while self.memory[-1] is None:
+            self.allocate_memory_1(1024)
+            self.allocate_memory_2(1024)
+
+    def grow_list(self, target: int) -> None:
+        self.memory = [None for _ in range(target)]
+
+    def allocate_memory_1(self, size: int) -> None:
+        self.memory[self.index] = bytearray(size)
+        self.index += 1
+
+    def allocate_memory_2(self, size: int) -> None:
+        self.memory[self.index] = bytearray(3 * size)
+        self.index += 1
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    Target().run()
+
+    prof.stop()

--- a/scenarios/python_alloc_3.14/requirements.txt
+++ b/scenarios/python_alloc_3.14/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace

--- a/scenarios/python_alloc_3.15/Dockerfile
+++ b/scenarios/python_alloc_3.15/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE="prof-python-3.15"
+FROM $BASE_IMAGE
+
+# ddtrace is pre-installed in the base image when DDTRACE_INSTALL_URL is set
+# (dd-trace-py downstream CI). Do not pip-install here — PyPI wheels may not
+# exist for 3.15 yet.
+
+COPY ./scenarios/python_alloc_3.15/main.py /app/main.py
+WORKDIR /app
+
+ENV DD_PROFILING_STACK_ENABLED=false
+ENV DD_PROFILING_LOCK_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_alloc_3.15/README.md
+++ b/scenarios/python_alloc_3.15/README.md
@@ -1,0 +1,21 @@
+## Allocation profiling (3.15 candidate)
+
+Validates that the Datadog Python profiler's **memory collector** reports
+`alloc-space` and `alloc-samples` with correct call stacks and `thread name`
+labels. This is the **3.15 candidate** half of the `3.14 -> 3.15` migration pair
+(see `python_alloc_3.14`).
+
+Reuses the workload from `scenarios/python_basic_memory_3.11`: two allocation
+sites with a 1:3 byte ratio (`allocate_memory_1` / `allocate_memory_2`).
+Stack and lock collectors are disabled to isolate allocation samples.
+
+## Expected profile
+
+Assertions match `python_basic_memory_3.11` (stable sampling proportions for
+`alloc-samples` and `alloc-space`).
+
+## Notes
+
+This scenario is wheel-only: PyPI ddtrace wheels may not exist for 3.15 yet, so
+it is excluded from prof-correctness `main` CI and runs via the dd-trace-py
+downstream gate (`DDTRACE_INSTALL_URL`).

--- a/scenarios/python_alloc_3.15/expected_profile.json
+++ b/scenarios/python_alloc_3.15/expected_profile.json
@@ -1,0 +1,127 @@
+{
+  "test_name": "python_alloc_3.15",
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
+          "percent": 35,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
+          "percent": 45,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^.*__init__;.*grow_list.*$",
+          "percent": 19,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_1.*$",
+          "percent": 25,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^\u003cmodule\u003e;run;allocate_memory_2.*$",
+          "percent": 75,
+          "error_margin": 5,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-space",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^.*grow_list.*$",
+          "percent": 3,
+          "error_margin": 3,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": [
+                "MainThread"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": false
+}

--- a/scenarios/python_alloc_3.15/main.py
+++ b/scenarios/python_alloc_3.15/main.py
@@ -1,0 +1,33 @@
+from ddtrace.profiling import Profiler
+
+
+class Target:
+    def __init__(self) -> None:
+        self.memory: list[bytearray | None] = []
+        self.index = 0
+        self.grow_list(target=int(1e6))
+
+    def run(self) -> None:
+        while self.memory[-1] is None:
+            self.allocate_memory_1(1024)
+            self.allocate_memory_2(1024)
+
+    def grow_list(self, target: int) -> None:
+        self.memory = [None for _ in range(target)]
+
+    def allocate_memory_1(self, size: int) -> None:
+        self.memory[self.index] = bytearray(size)
+        self.index += 1
+
+    def allocate_memory_2(self, size: int) -> None:
+        self.memory[self.index] = bytearray(3 * size)
+        self.index += 1
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    Target().run()
+
+    prof.stop()

--- a/scenarios/python_downstream_gate/README.md
+++ b/scenarios/python_downstream_gate/README.md
@@ -1,6 +1,6 @@
 # Python downstream gate (dd-trace-py)
 
-Eight prof-correctness scenarios exercise the profiling stack on **3.14
+Ten prof-correctness scenarios exercise the profiling stack on **3.14
 (baseline)** and **3.15 (candidate)** for the same workloads. They are the
 default set when dd-trace-py triggers downstream CI on profiling changes.
 
@@ -9,6 +9,7 @@ default set when dd-trace-py triggers downstream CI on profiling changes.
 | Family | 3.14 (baseline) | 3.15 (candidate) |
 |--------|-------------------|------------------|
 | cpu (stack) | `python_cpu_3.14` | `python_cpu_3.15` |
+| alloc (memory) | `python_alloc_3.14` | `python_alloc_3.15` |
 | exceptions | `python_exceptions_3.14` | `python_exceptions_3.15` |
 | async-gen | `python_async_gen_3.14` | `python_async_gen_3.15` |
 | lock | `python_lock_3.14` | `python_lock_3.15` |
@@ -18,17 +19,18 @@ default set when dd-trace-py triggers downstream CI on profiling changes.
 | Family | Profile type asserted | Collectors / setup |
 |--------|----------------------|--------------------|
 | cpu (stack) | `cpu-time` + `thread name` | Stack via `ddtrace-run`; memory off; CPU-bound loops |
+| alloc (memory) | `alloc-space` + `alloc-samples` | Memory profiler; stack/lock off |
 | exceptions | `exception-samples` + `exception type` | Exception profiler |
 | async-gen | `wall-time` | Full profiler via `ddtrace-run`; asyncio async-generator workload |
 | lock | `lock-acquire` + `lock-release` + `lock name` | Lock profiler; threaded lock churn |
 
-Feature-specific pairs (mem_domain, live_heap) and extended coverage (alloc,
-asyncio, …) land in follow-up PRs.
+Feature-specific pairs (mem_domain, live_heap) and extended coverage land in
+follow-up PRs.
 
 ## Default downstream regexp
 
 ```
-python_(cpu|exceptions|async_gen|lock)_3\.(14|15)
+python_(cpu|alloc|exceptions|async_gen|lock)_3\.(14|15)
 ```
 
 Override via `workflow_dispatch` → `test_scenarios`, or when triggering
@@ -43,7 +45,7 @@ Override via `workflow_dispatch` → `test_scenarios`, or when triggering
 
 ```sh
 export DDTRACE_INSTALL_URL="https://dd-trace-py-builds.s3.amazonaws.com/<commit-sha>/install.sh"
-TEST_SCENARIOS='python_(cpu|exceptions|async_gen|lock)_3\.(14|15)' go test -v -run TestScenarios
+TEST_SCENARIOS='python_(cpu|alloc|exceptions|async_gen|lock)_3\.(14|15)' go test -v -run TestScenarios
 ```
 
 ## Further reading


### PR DESCRIPTION
**Prev:** [#169](https://github.com/DataDog/prof-correctness/pull/169) | **Next:** [#171](https://github.com/DataDog/prof-correctness/pull/171)

## Motivation

**Allocation profiling** (`alloc-space`, `alloc-samples`) must produce consistent profiles across 3.14 and 3.15 — a key migration check for the memory collector and stack unwinder interaction.

## Summary

Adds paired **`python_alloc_3.14/3.15`** scenarios:

- Reuses `python_basic_memory_3.11` allocation workload
- Stack and lock collectors disabled to isolate alloc signals
- Asserts `alloc-space` and `alloc-samples` in expected profiles
- Both 3.15 runs wheel-only via `DDTRACE_INSTALL_URL`

Gate grows **8 → 10** scenarios.

## Test plan

- [x] `go test -run TestSchemaValidation`
- [x] `ruff check` on scenario sources
- [ ] Downstream gate with `DDTRACE_INSTALL_URL`

