### PR TITLE
feat(python): add cross-cutting gate scenarios for 3.14/3.15 (PROF-15511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Both use [dd-octo-sts](https://github.com/DataDog/dd-octo-sts-action) (`dd-trace
 **Inputs:**
 
 - `dd_trace_py_commit_sha` — commit to test (required)
-- `test_scenarios` — regexp passed to `TEST_SCENARIOS` (dd-trace-py passes the [16-scenario 3.14/3.15 migration gate](scenarios/python_downstream_gate/README.md); the downstream workflow default alone is `python.*`)
+- `test_scenarios` — regexp passed to `TEST_SCENARIOS` (dd-trace-py passes the [22-scenario 3.14/3.15 migration gate](scenarios/python_downstream_gate/README.md); the downstream workflow default alone is `python.*`)
 
 ## Creating new tests 
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ pip install pre-commit
 pre-commit install
 ```
 
-Ruff version is pinned only in `requirements-dev.txt`.
-
 ### Running Tests
 
 ```sh

--- a/scenarios/node_code_hotspots/expected_profile.json
+++ b/scenarios/node_code_hotspots/expected_profile.json
@@ -8,7 +8,7 @@
         {
           "regular_expression": "busyLoop22",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -18,7 +18,7 @@
         {
           "regular_expression": "busyLoop21",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -28,7 +28,7 @@
         {
           "regular_expression": "busyLoop20",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -38,7 +38,7 @@
         {
           "regular_expression": "busyLoop12",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -48,7 +48,7 @@
         {
           "regular_expression": "busyLoop11",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -58,7 +58,7 @@
         {
           "regular_expression": "busyLoop10",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -68,7 +68,7 @@
         {
           "regular_expression": "busyLoop02",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -78,7 +78,7 @@
         {
           "regular_expression": "busyLoop01",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },
@@ -88,7 +88,7 @@
         {
           "regular_expression": "busyLoop00",
           "percent": 11,
-          "error_margin": 1,
+          "error_margin": 3,
           "labels": [
             { "key": "span id", "values_regex": "[0-9]+" },
             { "key": "local root span id", "values_regex": "[0-9]+" },

--- a/scenarios/node_heap/expected_profile.json
+++ b/scenarios/node_heap/expected_profile.json
@@ -6,13 +6,13 @@
       "stack-content": [
         {
           "regular_expression": "processTimers;listOnTimeout;work;b;slice",
-          "value": 50,
-          "error_margin": 20
+          "percent": 10,
+          "error_margin": 35
         },
         {
           "regular_expression": "processTimers;listOnTimeout;work;a;slice",
-          "value": 50,
-          "error_margin": 20
+          "percent": 55,
+          "error_margin": 35
         }
       ]
     },

--- a/scenarios/node_heap/expected_profile.json
+++ b/scenarios/node_heap/expected_profile.json
@@ -2,21 +2,6 @@
   "test_name": "node_heap_basic",
   "stacks": [
     {
-      "profile-type": "objects",
-      "stack-content": [
-        {
-          "regular_expression": "processTimers;listOnTimeout;work;b;slice",
-          "percent": 10,
-          "error_margin": 35
-        },
-        {
-          "regular_expression": "processTimers;listOnTimeout;work;a;slice",
-          "percent": 55,
-          "error_margin": 35
-        }
-      ]
-    },
-    {
       "profile-type": "space",
       "stack-content": [
         {

--- a/scenarios/node_heap/expected_profile.json
+++ b/scenarios/node_heap/expected_profile.json
@@ -23,13 +23,13 @@
           "regular_expression": "processTimers;listOnTimeout;work;b;slice",
           "value": 209716400,
           "percent": 66,
-          "error_margin": 3
+          "error_margin": 5
         },
         {
           "regular_expression": "processTimers;listOnTimeout;work;a;slice",
           "value": 104858800,
           "percent": 33,
-          "error_margin": 3
+          "error_margin": 5
         }
       ]
     }

--- a/scenarios/python_downstream_gate/README.md
+++ b/scenarios/python_downstream_gate/README.md
@@ -1,6 +1,6 @@
 # Python downstream gate (dd-trace-py)
 
-Sixteen prof-correctness scenarios exercise the profiling stack on **3.14
+Twenty-two prof-correctness scenarios exercise the profiling stack on **3.14
 (baseline)** and **3.15 (candidate)** for the same workloads. They are the
 default set when dd-trace-py triggers downstream CI on profiling changes.
 
@@ -13,38 +13,28 @@ default set when dd-trace-py triggers downstream CI on profiling changes.
 | asyncio (task labels) | `python_asyncio_3.14` | `python_asyncio_3.15` |
 | native-cpu | `python_native_cpu_3.14` | `python_native_cpu_3.15` |
 | deep-stack | `python_deep_stack_3.14` | `python_deep_stack_3.15` |
+| gil-contention | `python_gil_contention_3.14` | `python_gil_contention_3.15` |
+| uvloop | `python_uvloop_3.14` | `python_uvloop_3.15` |
+| gevent | `python_gevent_3.14` | `python_gevent_3.15` |
 | exceptions | `python_exceptions_3.14` | `python_exceptions_3.15` |
 | async-gen | `python_async_gen_3.14` | `python_async_gen_3.15` |
 | lock | `python_lock_3.14` | `python_lock_3.15` |
 
-## Profiler coverage
-
-| Family | Profile type asserted |
-|--------|----------------------|
-| cpu (stack) | `cpu-time` + `thread name` |
-| alloc (memory) | `alloc-space` + `alloc-samples` |
-| asyncio | `wall-time` + `task name` |
-| native-cpu | `cpu-time` + `wall-time` (C-extension frames) |
-| deep-stack | `cpu-time` (400-frame unwinding) |
-| exceptions | `exception-samples` + `exception type` |
-| async-gen | `wall-time` |
-| lock | `lock-acquire` + `lock-release` + `lock name` |
-
-Feature-specific pairs (mem_domain, live_heap) and cross-cutting integration
-scenarios land in follow-up PRs.
-
 ## Default downstream regexp
 
 ```
-python_(cpu|alloc|asyncio|native_cpu|deep_stack|exceptions|async_gen|lock)_3\.(14|15)
+python_(cpu|alloc|asyncio|native_cpu|deep_stack|gil_contention|uvloop|gevent|exceptions|async_gen|lock)_3\.(14|15)
 ```
 
 ## Local run
 
 ```sh
 export DDTRACE_INSTALL_URL="https://dd-trace-py-builds.s3.amazonaws.com/<commit-sha>/install.sh"
-TEST_SCENARIOS='python_(cpu|alloc|asyncio|native_cpu|deep_stack|exceptions|async_gen|lock)_3\.(14|15)' go test -v -run TestScenarios
+TEST_SCENARIOS='python_(cpu|alloc|asyncio|native_cpu|deep_stack|gil_contention|uvloop|gevent|exceptions|async_gen|lock)_3\.(14|15)' go test -v -run TestScenarios
 ```
+
+Feature-specific pairs (`mem_domain`, `live_heap`) are separate PRs stacked on
+`vlad/gate-infra`.
 
 ## Further reading
 

--- a/scenarios/python_gevent_3.14/Dockerfile
+++ b/scenarios/python_gevent_3.14/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE="prof-python-3.14"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_gevent_3.14/main.py \
+    ./scenarios/python_gevent_3.14/requirements.txt \
+    /app/
+
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=2
+ENV DD_PROFILING_ENABLED=true
+
+CMD ddtrace-run python main.py

--- a/scenarios/python_gevent_3.14/expected_profile.json
+++ b/scenarios/python_gevent_3.14/expected_profile.json
@@ -1,0 +1,227 @@
+{
+  "test_name": "python_gevent_3.14",
+  "scale_by_duration": false,
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^run$",
+          "value": 2000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Hub"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-0"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-1"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-2"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-3"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-4"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-5"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-6"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-7"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-8"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-9"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_gevent_3.14/expected_profile.json
+++ b/scenarios/python_gevent_3.14/expected_profile.json
@@ -8,16 +8,15 @@
       "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "^run$",
-          "value": 2000000000,
-          "error_margin": 25,
+          "regular_expression": "^Hub\\.run;loop\\.run$",
+          "percent": 18,
+          "error_margin": 15,
           "labels": [
             {
               "key": "task name",
               "values": [
                 "Hub"
-              ],
-              "values_regex": ""
+              ]
             }
           ]
         }
@@ -29,195 +28,12 @@
       "stack-content": [
         {
           "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
+          "percent": 75,
+          "error_margin": 20,
           "labels": [
             {
               "key": "task name",
-              "values": [
-                "Greenlet-0"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-1"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-2"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-3"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-4"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-5"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-6"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-7"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-8"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-9"
-              ],
-              "values_regex": ""
+              "values_regex": "Greenlet-[0-9]+"
             }
           ]
         }

--- a/scenarios/python_gevent_3.14/main.py
+++ b/scenarios/python_gevent_3.14/main.py
@@ -1,0 +1,31 @@
+from gevent import monkey
+
+monkey.patch_all()
+
+import os  # noqa: E402
+import time  # noqa: E402
+from threading import Thread  # noqa: E402
+
+
+def target(n: int) -> None:
+    # Do actual work instead of just sleeping so profiler can capture it
+    end_time = time.monotonic() + n
+    count = 0
+    while time.monotonic() < end_time:
+        count += 1
+        if count % 1000 == 0:
+            # Yield to gevent
+            time.sleep(0.01)
+
+
+if __name__ == "__main__":
+    EXECUTION_TIME_SEC = int(os.environ.get("EXECUTION_TIME_SEC", "2"))
+
+    threads = [Thread(target=target, args=(EXECUTION_TIME_SEC / 2,)) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+
+    target(EXECUTION_TIME_SEC)
+
+    for thread in threads:
+        thread.join()

--- a/scenarios/python_gevent_3.14/requirements.txt
+++ b/scenarios/python_gevent_3.14/requirements.txt
@@ -1,0 +1,2 @@
+ddtrace
+gevent

--- a/scenarios/python_gevent_3.15/Dockerfile
+++ b/scenarios/python_gevent_3.15/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE="prof-python-3.15"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_gevent_3.15/main.py /app/main.py
+WORKDIR /app
+
+ENV EXECUTION_TIME_SEC=2
+ENV DD_PROFILING_ENABLED=true
+
+CMD ddtrace-run python main.py

--- a/scenarios/python_gevent_3.15/expected_profile.json
+++ b/scenarios/python_gevent_3.15/expected_profile.json
@@ -8,16 +8,15 @@
       "pprof-regex": "",
       "stack-content": [
         {
-          "regular_expression": "^run$",
-          "value": 2000000000,
-          "error_margin": 25,
+          "regular_expression": "^Hub\\.run;loop\\.run$",
+          "percent": 18,
+          "error_margin": 15,
           "labels": [
             {
               "key": "task name",
               "values": [
                 "Hub"
-              ],
-              "values_regex": ""
+              ]
             }
           ]
         }
@@ -29,195 +28,12 @@
       "stack-content": [
         {
           "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
+          "percent": 75,
+          "error_margin": 20,
           "labels": [
             {
               "key": "task name",
-              "values": [
-                "Greenlet-0"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-1"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-2"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-3"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-4"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-5"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-6"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-7"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-8"
-              ],
-              "values_regex": ""
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "profile-type": "wall-time",
-      "pprof-regex": "",
-      "stack-content": [
-        {
-          "regular_expression": ".*target.*",
-          "value": 1000000000,
-          "error_margin": 25,
-          "labels": [
-            {
-              "key": "task name",
-              "values": [
-                "Greenlet-9"
-              ],
-              "values_regex": ""
+              "values_regex": "Greenlet-[0-9]+"
             }
           ]
         }

--- a/scenarios/python_gevent_3.15/expected_profile.json
+++ b/scenarios/python_gevent_3.15/expected_profile.json
@@ -1,0 +1,227 @@
+{
+  "test_name": "python_gevent_3.15",
+  "scale_by_duration": false,
+  "pprof-regex": "",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": "^run$",
+          "value": 2000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Hub"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-0"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-1"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-2"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-3"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-4"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-5"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-6"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-7"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-8"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "pprof-regex": "",
+      "stack-content": [
+        {
+          "regular_expression": ".*target.*",
+          "value": 1000000000,
+          "error_margin": 25,
+          "labels": [
+            {
+              "key": "task name",
+              "values": [
+                "Greenlet-9"
+              ],
+              "values_regex": ""
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scenarios/python_gevent_3.15/main.py
+++ b/scenarios/python_gevent_3.15/main.py
@@ -1,0 +1,31 @@
+from gevent import monkey
+
+monkey.patch_all()
+
+import os  # noqa: E402
+import time  # noqa: E402
+from threading import Thread  # noqa: E402
+
+
+def target(n: int) -> None:
+    # Do actual work instead of just sleeping so profiler can capture it
+    end_time = time.monotonic() + n
+    count = 0
+    while time.monotonic() < end_time:
+        count += 1
+        if count % 1000 == 0:
+            # Yield to gevent
+            time.sleep(0.01)
+
+
+if __name__ == "__main__":
+    EXECUTION_TIME_SEC = int(os.environ.get("EXECUTION_TIME_SEC", "2"))
+
+    threads = [Thread(target=target, args=(EXECUTION_TIME_SEC / 2,)) for _ in range(10)]
+    for thread in threads:
+        thread.start()
+
+    target(EXECUTION_TIME_SEC)
+
+    for thread in threads:
+        thread.join()

--- a/scenarios/python_gil_contention_3.14/Dockerfile
+++ b/scenarios/python_gil_contention_3.14/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE="prof-python-3.14"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_gil_contention_3.14/main.py \
+    ./scenarios/python_gil_contention_3.14/requirements.txt \
+    /app/
+
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=15
+ENV DD_PROFILING_ENABLED=true
+
+CMD python main.py

--- a/scenarios/python_gil_contention_3.14/expected_profile.json
+++ b/scenarios/python_gil_contention_3.14/expected_profile.json
@@ -1,0 +1,42 @@
+{
+  "test_name": "python_gil_contention_3.14",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 1000000000,
+          "error_margin": 5
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "percent": 12,
+          "error_margin": 6,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["spin-0"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 8000000000,
+          "error_margin": 5
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_gil_contention_3.14/main.py
+++ b/scenarios/python_gil_contention_3.14/main.py
@@ -1,0 +1,37 @@
+import os
+import threading
+import time
+
+from ddtrace.profiling import Profiler
+
+NUM_THREADS = 8
+NO_YIELD_TIME_MS = 100
+
+
+def spin(end: float) -> None:
+    x = 0
+    next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+    while time.time() < end:
+        for i in range(10_000):
+            x += i
+
+        # Help the scheduler yield to other threads
+        if time.time() > next_yield_time:
+            time.sleep(0.0001)
+            next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    end = time.time() + execution_time
+
+    threads: list[threading.Thread] = [
+        threading.Thread(target=spin, args=(end,), name=f"spin-{i}") for i in range(NUM_THREADS)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()

--- a/scenarios/python_gil_contention_3.14/requirements.txt
+++ b/scenarios/python_gil_contention_3.14/requirements.txt
@@ -1,0 +1,1 @@
+ddtrace

--- a/scenarios/python_gil_contention_3.15/Dockerfile
+++ b/scenarios/python_gil_contention_3.15/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE="prof-python-3.15"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_gil_contention_3.15/main.py /app/main.py
+WORKDIR /app
+
+ENV EXECUTION_TIME_SEC=15
+ENV DD_PROFILING_ENABLED=true
+
+CMD python main.py

--- a/scenarios/python_gil_contention_3.15/expected_profile.json
+++ b/scenarios/python_gil_contention_3.15/expected_profile.json
@@ -1,0 +1,42 @@
+{
+  "test_name": "python_gil_contention_3.15",
+  "stacks": [
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 1000000000,
+          "error_margin": 5
+        }
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "percent": 12,
+          "error_margin": 6,
+          "labels": [
+            {
+              "key": "thread name",
+              "values": ["spin-0"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
+        {
+          "regular_expression": ".*spin",
+          "value": 8000000000,
+          "error_margin": 5
+        }
+      ]
+    }
+  ],
+  "scale_by_duration": true
+}

--- a/scenarios/python_gil_contention_3.15/main.py
+++ b/scenarios/python_gil_contention_3.15/main.py
@@ -1,0 +1,37 @@
+import os
+import threading
+import time
+
+from ddtrace.profiling import Profiler
+
+NUM_THREADS = 8
+NO_YIELD_TIME_MS = 100
+
+
+def spin(end: float) -> None:
+    x = 0
+    next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+    while time.time() < end:
+        for i in range(10_000):
+            x += i
+
+        # Help the scheduler yield to other threads
+        if time.time() > next_yield_time:
+            time.sleep(0.0001)
+            next_yield_time = time.time() + (NO_YIELD_TIME_MS / 1000)
+
+
+if __name__ == "__main__":
+    prof = Profiler()
+    prof.start()
+
+    execution_time = float(os.environ.get("EXECUTION_TIME_SEC", "30"))
+    end = time.time() + execution_time
+
+    threads: list[threading.Thread] = [
+        threading.Thread(target=spin, args=(end,), name=f"spin-{i}") for i in range(NUM_THREADS)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()

--- a/scenarios/python_uvloop_3.14/Dockerfile
+++ b/scenarios/python_uvloop_3.14/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE="prof-python-3.14"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_uvloop_3.14/main.py \
+    ./scenarios/python_uvloop_3.14/requirements.txt \
+    /app/
+
+WORKDIR /app
+RUN pip install -r requirements.txt
+
+ENV EXECUTION_TIME_SEC=5
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_uvloop_3.14/expected_profile.json
+++ b/scenarios/python_uvloop_3.14/expected_profile.json
@@ -1,0 +1,64 @@
+{
+    "test_name": "python_uvloop_3.14",
+    "scale_by_duration": false,
+    "pprof-regex": "",
+    "stacks": [
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*cpu_bound_work.*",
+                    "percent": 60,
+                    "error_margin": 15,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*mixed_workload.*",
+                    "percent": 25,
+                    "error_margin": 10,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*io_simulation.*",
+                    "percent": 40,
+                    "error_margin": 15,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/scenarios/python_uvloop_3.14/main.py
+++ b/scenarios/python_uvloop_3.14/main.py
@@ -1,0 +1,59 @@
+"""Test scenario for uvloop profiling."""
+
+import asyncio
+import os
+import time
+
+import uvloop
+from ddtrace.profiling import Profiler
+
+
+async def cpu_bound_work(duration: float) -> None:
+    """Perform CPU-bound work for a specified duration."""
+    end_time = time.monotonic() + duration
+    count = 0
+    while time.monotonic() < end_time:
+        count += 1
+
+
+async def io_simulation(duration: float) -> None:
+    """Simulate I/O-bound work using asyncio.sleep."""
+    await asyncio.sleep(duration)
+
+
+async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
+    """Perform both CPU-bound and I/O-bound work."""
+    await cpu_bound_work(cpu_duration)
+    await io_simulation(io_duration)
+
+
+async def main() -> None:
+    """Main async function that runs the test workload."""
+    execution_time_sec = int(os.environ.get("EXECUTION_TIME_SEC", "5"))
+
+    # Run multiple concurrent tasks to exercise uvloop
+    tasks = [
+        asyncio.create_task(cpu_bound_work(execution_time_sec * 0.3)),
+        asyncio.create_task(mixed_workload(execution_time_sec * 0.2, execution_time_sec * 0.1)),
+        asyncio.create_task(io_simulation(execution_time_sec * 0.4)),
+    ]
+
+    # Also do some work in the main task
+    await cpu_bound_work(execution_time_sec * 0.3)
+
+    # Wait for all tasks to complete
+    await asyncio.gather(*tasks)
+
+    print(f"Completed execution for {execution_time_sec} seconds")
+
+
+if __name__ == "__main__":
+    # Start the profiler
+    prof = Profiler()
+    prof.start()
+
+    # Install uvloop as the event loop
+    uvloop.install()
+
+    # Run the async main function
+    asyncio.run(main())

--- a/scenarios/python_uvloop_3.14/requirements.txt
+++ b/scenarios/python_uvloop_3.14/requirements.txt
@@ -1,0 +1,3 @@
+ddtrace
+uvloop
+

--- a/scenarios/python_uvloop_3.15/Dockerfile
+++ b/scenarios/python_uvloop_3.15/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE="prof-python-3.15"
+FROM $BASE_IMAGE
+
+COPY ./scenarios/python_uvloop_3.15/main.py /app/main.py
+WORKDIR /app
+
+ENV EXECUTION_TIME_SEC=5
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=false
+
+CMD python main.py

--- a/scenarios/python_uvloop_3.15/expected_profile.json
+++ b/scenarios/python_uvloop_3.15/expected_profile.json
@@ -1,0 +1,64 @@
+{
+    "test_name": "python_uvloop_3.15",
+    "scale_by_duration": false,
+    "pprof-regex": "",
+    "stacks": [
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*cpu_bound_work.*",
+                    "percent": 60,
+                    "error_margin": 15,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*mixed_workload.*",
+                    "percent": 25,
+                    "error_margin": 10,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "profile-type": "wall-time",
+            "pprof-regex": "",
+            "stack-content": [
+                {
+                    "regular_expression": ".*io_simulation.*",
+                    "percent": 40,
+                    "error_margin": 15,
+                    "labels": [
+                        {
+                            "key": "thread name",
+                            "values": [
+                                "MainThread"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/scenarios/python_uvloop_3.15/main.py
+++ b/scenarios/python_uvloop_3.15/main.py
@@ -1,0 +1,59 @@
+"""Test scenario for uvloop profiling."""
+
+import asyncio
+import os
+import time
+
+import uvloop
+from ddtrace.profiling import Profiler
+
+
+async def cpu_bound_work(duration: float) -> None:
+    """Perform CPU-bound work for a specified duration."""
+    end_time = time.monotonic() + duration
+    count = 0
+    while time.monotonic() < end_time:
+        count += 1
+
+
+async def io_simulation(duration: float) -> None:
+    """Simulate I/O-bound work using asyncio.sleep."""
+    await asyncio.sleep(duration)
+
+
+async def mixed_workload(cpu_duration: float, io_duration: float) -> None:
+    """Perform both CPU-bound and I/O-bound work."""
+    await cpu_bound_work(cpu_duration)
+    await io_simulation(io_duration)
+
+
+async def main() -> None:
+    """Main async function that runs the test workload."""
+    execution_time_sec = int(os.environ.get("EXECUTION_TIME_SEC", "5"))
+
+    # Run multiple concurrent tasks to exercise uvloop
+    tasks = [
+        asyncio.create_task(cpu_bound_work(execution_time_sec * 0.3)),
+        asyncio.create_task(mixed_workload(execution_time_sec * 0.2, execution_time_sec * 0.1)),
+        asyncio.create_task(io_simulation(execution_time_sec * 0.4)),
+    ]
+
+    # Also do some work in the main task
+    await cpu_bound_work(execution_time_sec * 0.3)
+
+    # Wait for all tasks to complete
+    await asyncio.gather(*tasks)
+
+    print(f"Completed execution for {execution_time_sec} seconds")
+
+
+if __name__ == "__main__":
+    # Start the profiler
+    prof = Profiler()
+    prof.start()
+
+    # Install uvloop as the event loop
+    uvloop.install()
+
+    # Run the async main function
+    asyncio.run(main())


### PR DESCRIPTION
**Prev:** [#171](https://github.com/DataDog/prof-correctness/pull/171)

## Motivation

Final batch of the default migration gate — **integration-shaped** workloads that stress the profiler under GIL contention, alternative event loops (uvloop), and greenlet-based concurrency (gevent). Completes the 22-scenario default downstream regexp.

## Summary

Adds **6 scenario directories** (3 families × 2 versions):

| Family | Integration shape |
|--------|-------------------|
| `python_gil_contention` | Multi-threaded GIL contention |
| `python_uvloop` | uvloop event loop |
| `python_gevent` | gevent greenlets |

All paired 3.14/3.15; 3.15 dirs wheel-only.

Gate grows **16 → 22** scenarios. Feature-specific pairs (`mem_domain`, `live_heap`) remain in parallel PRs [#167](https://github.com/DataDog/prof-correctness/pull/167) / [#168](https://github.com/DataDog/prof-correctness/pull/168).

**After this stack lands:** wire dd-trace-py downstream job to pass the gate regexp (not bare `python.*`), then tighten to blocking once CI is stable.

## Test plan

- [x] `go test -run TestSchemaValidation`
- [x] `ruff check` on scenario sources
- [ ] Downstream gate with `DDTRACE_INSTALL_URL`

