### PR TITLE
chore(ci): pin ruff and add pre-commit hooks (PROF-15511)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: pip install --no-cache-dir ruff
+        run: pip install --no-cache-dir ruff==0.15.5
       - name: Run ruff format check
         run: ruff format --check .
       - name: Run ruff lint check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: pip install --no-cache-dir ruff==0.15.5
+        run: pip install --no-cache-dir -r requirements-dev.txt
       - name: Run ruff format check
         run: ruff format --check .
       - name: Run ruff lint check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+# Lightweight Python formatting/lint for scenario workloads. Matches the ruff job in ci.yml.
+# Install: pip install pre-commit && pre-commit install
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.5
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # Lightweight Python formatting/lint for scenario workloads. Matches the ruff job in ci.yml.
-# Install: pip install pre-commit && pre-commit install
+# Local: ./scripts/lint (check) or ./scripts/format (auto-fix)
+# Optional hooks (skipped when core.hooksPath is set): pip install pre-commit && pre-commit install
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:
-      - id: ruff-format
       - id: ruff
         args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
-# Lightweight Python formatting/lint for scenario workloads. Matches the ruff job in ci.yml.
-# Local: ./scripts/lint (check) or ./scripts/format (auto-fix)
-# Optional hooks (skipped when core.hooksPath is set): pip install pre-commit && pre-commit install
+# Optional git hooks for Python scenario files (same checks as CI — see scripts/lint).
+# Setup: pip install -r requirements-dev.txt pre-commit && pre-commit install
+# On Datadog laptops with global core.hooksPath, use ./scripts/lint instead of pre-commit install.
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.5
+  - repo: local
     hooks:
       - id: ruff
-        args: [--fix]
-      - id: ruff-format
+        name: ruff (scripts/lint)
+        entry: scripts/lint
+        language: system
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ Checkout #profiling-library-pager to get notified of test failures.
 Install go >= 1.25.1: `brew install go`, `choco install go`, etc.
 Install docker.
 
+### Python lint (scenario workloads)
+
+CI and local checks use [Ruff](https://docs.astral.sh/ruff/). Install once:
+
+```sh
+pip install -r requirements-dev.txt
+```
+
+```sh
+./scripts/lint          # check (matches the ci.yml ruff job)
+./scripts/format        # auto-fix formatting and lint
+```
+
+Optional git hooks (skip on Datadog laptops that use global `core.hooksPath` — run `./scripts/lint` manually instead):
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+Ruff version is pinned only in `requirements-dev.txt`.
+
 ### Running Tests
 
 ```sh

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Python dev tools for repo-wide lint/format (ci.yml, scripts/lint, scripts/format, pre-commit).
+ruff==0.15.5

--- a/scenarios/python_safe_point_bias_3.11/README.md
+++ b/scenarios/python_safe_point_bias_3.11/README.md
@@ -10,6 +10,7 @@ Verifies that the Python profiler correctly attributes CPU time to `slow_method`
 def empty_method() -> None:
     pass
 
+
 def slow_method() -> None:
     while time() < end_time:
         x = "h" + "e" + "l" + "l" + "o" + ","

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if ! command -v ruff >/dev/null 2>&1; then
+  echo "ruff not found; install with: pip install ruff==0.15.5" >&2
+  exit 1
+fi
+
+targets=("$@")
+if [ "${#targets[@]}" -eq 0 ]; then
+  targets=(".")
+fi
+
+ruff format "${targets[@]}"
+ruff check --fix "${targets[@]}"

--- a/scripts/format
+++ b/scripts/format
@@ -14,5 +14,5 @@ if [ "${#targets[@]}" -eq 0 ]; then
   targets=(".")
 fi
 
-ruff format "${targets[@]}"
 ruff check --fix "${targets[@]}"
+ruff format "${targets[@]}"

--- a/scripts/format
+++ b/scripts/format
@@ -1,19 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$root"
-dev_requirements="$root/requirements-dev.txt"
+source "$(dirname "${BASH_SOURCE[0]}")/ruff-common.sh"
+ruff_common_setup
+ruff_resolve_targets "$@"
 
-if ! command -v ruff >/dev/null 2>&1; then
-  echo "ruff not found; install with: pip install -r $dev_requirements" >&2
-  exit 1
-fi
-
-targets=("$@")
-if [ "${#targets[@]}" -eq 0 ]; then
-  targets=(".")
-fi
-
-ruff check --fix "${targets[@]}"
-ruff format "${targets[@]}"
+ruff check --fix "${RUFF_TARGETS[@]}"
+ruff format "${RUFF_TARGETS[@]}"

--- a/scripts/format
+++ b/scripts/format
@@ -3,9 +3,10 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
+dev_requirements="$root/requirements-dev.txt"
 
 if ! command -v ruff >/dev/null 2>&1; then
-  echo "ruff not found; install with: pip install ruff==0.15.5" >&2
+  echo "ruff not found; install with: pip install -r $dev_requirements" >&2
   exit 1
 fi
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -2,19 +2,9 @@
 set -euo pipefail
 
 # Matches the ruff job in .github/workflows/ci.yml (see also scripts/format).
-root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$root"
-dev_requirements="$root/requirements-dev.txt"
+source "$(dirname "${BASH_SOURCE[0]}")/ruff-common.sh"
+ruff_common_setup
+ruff_resolve_targets "$@"
 
-if ! command -v ruff >/dev/null 2>&1; then
-  echo "ruff not found; install with: pip install -r $dev_requirements" >&2
-  exit 1
-fi
-
-targets=("$@")
-if [ "${#targets[@]}" -eq 0 ]; then
-  targets=(".")
-fi
-
-ruff format --check "${targets[@]}"
-ruff check "${targets[@]}"
+ruff format --check "${RUFF_TARGETS[@]}"
+ruff check "${RUFF_TARGETS[@]}"

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Matches the ruff job in .github/workflows/ci.yml (see also scripts/format).
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if ! command -v ruff >/dev/null 2>&1; then
+  echo "ruff not found; install with: pip install ruff==0.15.5" >&2
+  exit 1
+fi
+
+targets=("$@")
+if [ "${#targets[@]}" -eq 0 ]; then
+  targets=(".")
+fi
+
+ruff format --check "${targets[@]}"
+ruff check "${targets[@]}"

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,9 +4,10 @@ set -euo pipefail
 # Matches the ruff job in .github/workflows/ci.yml (see also scripts/format).
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$root"
+dev_requirements="$root/requirements-dev.txt"
 
 if ! command -v ruff >/dev/null 2>&1; then
-  echo "ruff not found; install with: pip install ruff==0.15.5" >&2
+  echo "ruff not found; install with: pip install -r $dev_requirements" >&2
   exit 1
 fi
 

--- a/scripts/ruff-common.sh
+++ b/scripts/ruff-common.sh
@@ -1,0 +1,17 @@
+# Shared setup for scripts/lint and scripts/format.
+ruff_common_setup() {
+  RUFF_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  cd "$RUFF_ROOT"
+
+  if ! command -v ruff >/dev/null 2>&1; then
+    echo "ruff not found; install with: pip install -r $RUFF_ROOT/requirements-dev.txt" >&2
+    exit 1
+  fi
+}
+
+ruff_resolve_targets() {
+  RUFF_TARGETS=("$@")
+  if [ "${#RUFF_TARGETS[@]}" -eq 0 ]; then
+    RUFF_TARGETS=(".")
+  fi
+}


### PR DESCRIPTION
**Next:** [#165](https://github.com/DataDog/prof-correctness/pull/165)

## Summary

Started implementing pre-commit hooks for automated lints and formatting fixes before the issues hit CI in PR. Cheap prevention of stuck PRs needing CI reruns.

### Changes

- **`requirements-dev.txt`** — single pin for `ruff==0.15.5` (CI, scripts, install docs)
- **CI** — `pip install -r requirements-dev.txt`; `ruff format --check` + `ruff check` (unchanged behavior, pinned version)
- **`scripts/lint` / `scripts/format`** — local wrappers matching CI vs auto-fix; shared setup in `scripts/ruff-common.sh`
  - Fix before format (`ruff check --fix` → `ruff format`) so one `./scripts/format` run converges
- **`.pre-commit-config.yaml`** — optional local hook calling `scripts/lint` (`language: system`; no second ruff version pin via `astral-sh/ruff-pre-commit`)
- **`README.md`** — Python lint setup (`pip install -r requirements-dev.txt`, scripts, optional pre-commit)
- **Formatting** — `ruff format` fix in `scenarios/python_safe_point_bias_3.11/README.md`

### Local workflow

```bash
pip install -r requirements-dev.txt
./scripts/lint      # check (matches CI)
./scripts/format    # auto-fix
