### PR TITLE
fix: allow tag refs to trigger prof-correctness via octo-sts

### DIFF
--- a/.github/chainguard/dd-trace-py.gitlab.trigger-ci.sts.yaml
+++ b/.github/chainguard/dd-trace-py.gitlab.trigger-ci.sts.yaml
@@ -2,13 +2,13 @@
 # Allows dd-trace-py GitLab CI to trigger prof-correctness GitHub Actions workflows
 # when profiling code changes, to run correctness tests against just-built wheels.
 issuer: https://gitlab.ddbuild.io
-subject_pattern: project_path:DataDog/apm-reliability/dd-trace-py:ref_type:branch:ref:.*
+subject_pattern: project_path:DataDog/apm-reliability/dd-trace-py:ref_type:(branch|tag):ref:.*
 
 claim_pattern:
-  ci_config_ref_uri: gitlab\.ddbuild\.io/DataDog/apm-reliability/dd-trace-py//\.gitlab-ci\.yml@refs/heads/.*
+  ci_config_ref_uri: gitlab\.ddbuild\.io/DataDog/apm-reliability/dd-trace-py//\.gitlab-ci\.yml@refs/(heads|tags)/.*
   pipeline_source: (push|schedule|web)
   project_path: DataDog/apm-reliability/dd-trace-py
-  ref_path: refs/heads/.*
+  ref_path: refs/(heads|tags)/.*
 
 permissions:
   actions: write


### PR DESCRIPTION
## What

Widen the `dd-trace-py.gitlab.trigger-ci` octo-sts trust policy to accept **tag** refs in addition to branch refs.

## Why

The policy only matched branch refs (`ref_type:branch`, `refs/heads/*`). Pipelines triggered from a **tag** (e.g. dd-trace-py release tag `v4.11.3`) presented `ref_type:tag` / `refs/tags/*`, so token issuance failed with:

```
http error with status code 403: {"code":7,"message":"permission denied"}
gh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.
```

That left `GH_TOKEN` empty and the downstream `prof-correctness` trigger could not run (ref: dd-trace-py job [1903242614](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-py/-/jobs/1903242614)).

## Change

Three patterns now accept `branch|tag` / `heads|tags`:
- `subject_pattern`: `ref_type:(branch|tag)`
- `claim_pattern.ci_config_ref_uri`: `@refs/(heads|tags)/.*`
- `claim_pattern.ref_path`: `refs/(heads|tags)/.*`

`project_path`, `pipeline_source`, and `permissions: actions: write` are unchanged, so the trust boundary (dd-trace-py project only) is preserved. Branch refs were already fully allowed (`ref:.*`); this only adds tags.